### PR TITLE
Shift scaled data by mean before basis representation

### DIFF
--- a/step2_preprocess.py
+++ b/step2_preprocess.py
@@ -42,7 +42,7 @@ import step2b_basis as step2b
 import step2c_project as step2c
 
 
-def main(trainsize, num_modes, weights=None):
+def main(trainsize, num_modes):
     """Lift and scale the GEMS simulation data; compute a POD basis of the
     lifted, scaled snapshot training data; project the lifted, scaled snapshot
     training data to the subspace spanned by the columns of the POD basis V,
@@ -59,23 +59,20 @@ def main(trainsize, num_modes, weights=None):
         The number of POD modes (left singular vectors) to use in the
         projection. This is the upper bound for the size of ROMs that
         can be trained with this data set.
-
-    weights : (trainsize,) ndarray or None
-        If given, weights for each snapshot in the POD basis computation.
     """
     utils.reset_logger(trainsize)
 
     # STEP 2A: Lift and scale the data ----------------------------------------
     try:
         # Attempt to load existing lifted, scaled data.
-        training_data, t, qbar, scales = utils.load_scaled_data(trainsize)
+        training_data, time, qbar, scales = utils.load_scaled_data(trainsize)
 
     except utils.DataNotFoundError:
         # Lift the GEMS data, then scale the lifted snapshots by variable.
-        lifted_data, t = step2a.load_and_lift_gems_data(trainsize)
+        lifted_data, time = step2a.load_and_lift_gems_data(trainsize)
         training_data, qbar, scales = step2a.scale_and_save_data(trainsize,
-                                                               lifted_data,
-                                                               t, weights)
+                                                                 lifted_data,
+                                                                 time)
         del lifted_data
 
     # STEP 2B: Get the POD basis from the lifted, scaled data -----------------
@@ -92,7 +89,7 @@ def main(trainsize, num_modes, weights=None):
                                                   training_data, scales)
 
     # STEP 2C: Project data to the appropriate subspace -----------------------
-    return step2c.project_and_save_data(training_data, t, basis)
+    return step2c.project_and_save_data(training_data, time, basis)
 
 
 # =============================================================================

--- a/step2_preprocess.py
+++ b/step2_preprocess.py
@@ -42,7 +42,7 @@ import step2b_basis as step2b
 import step2c_project as step2c
 
 
-def main(trainsize, num_modes):
+def main(trainsize, num_modes, weights=None):
     """Lift and scale the GEMS simulation data; compute a POD basis of the
     lifted, scaled snapshot training data; project the lifted, scaled snapshot
     training data to the subspace spanned by the columns of the POD basis V,
@@ -59,26 +59,29 @@ def main(trainsize, num_modes):
         The number of POD modes (left singular vectors) to use in the
         projection. This is the upper bound for the size of ROMs that
         can be trained with this data set.
+
+    weights : (trainsize,) ndarray or None
+        If given, weights for each snapshot in the POD basis computation.
     """
     utils.reset_logger(trainsize)
 
     # STEP 2A: Lift and scale the data ----------------------------------------
     try:
         # Attempt to load existing lifted, scaled data.
-        scaled_data, time_domain, scales = utils.load_scaled_data(trainsize)
+        training_data, t, qbar, scales = utils.load_scaled_data(trainsize)
 
     except utils.DataNotFoundError:
         # Lift the GEMS data, then scale the lifted snapshots by variable.
-        lifted_data, time_domain = step2a.load_and_lift_gems_data(trainsize)
-        scaled_data, scales = step2a.scale_and_save_data(trainsize,
-                                                         lifted_data,
-                                                         time_domain)
+        lifted_data, t = step2a.load_and_lift_gems_data(trainsize)
+        training_data, qbar, scales = step2a.scale_and_save_data(trainsize,
+                                                               lifted_data,
+                                                               t, weights)
         del lifted_data
 
     # STEP 2B: Get the POD basis from the lifted, scaled data -----------------
     try:
         # Attempt to load existing SVD data.
-        basis, scales = utils.load_basis(trainsize, None)
+        basis, qbar, scales = utils.load_basis(trainsize, None)
         if basis.shape[1] < num_modes:
             raise utils.DataNotFoundError("not enough saved basis vectors")
         num_modes = basis.shape[1]      # Use larger basis size if available.
@@ -86,10 +89,10 @@ def main(trainsize, num_modes):
     except utils.DataNotFoundError as e:
         # Compute and save the (randomized) SVD from the training data.
         basis = step2b.compute_and_save_pod_basis(num_modes,
-                                                  scaled_data, scales)
+                                                  training_data, scales)
 
     # STEP 2C: Project data to the appropriate subspace -----------------------
-    return step2c.project_and_save_data(scaled_data, time_domain, basis)
+    return step2c.project_and_save_data(training_data, t, basis)
 
 
 # =============================================================================

--- a/step2a_transform.py
+++ b/step2a_transform.py
@@ -85,8 +85,8 @@ def scale_and_save_data(trainsize, lifted_data, time_domain):
 
     # Shift the scaled data by the mean snapshot.
     with utils.timed_block(f"Shifting {trainsize:d} scaled snapshots by mean"):
-        qbar = np.mean(training_data, axis=1)           # Standard mean
-        training_data -= qbar.reshape((-1,1))           # Shift by mean
+        qbar = np.mean(training_data, axis=1)       # Compute mean snapshot.
+        training_data -= qbar.reshape((-1,1))       # Shift columns by mean.
 
     # Save the lifted, scaled training data.
     save_path = config.scaled_data_path(trainsize)

--- a/step2a_transform.py
+++ b/step2a_transform.py
@@ -22,7 +22,6 @@ Command Line Arguments
 import h5py
 import logging
 import numpy as np
-import scipy.spatial as sp
 
 import config
 import utils
@@ -55,65 +54,7 @@ def load_and_lift_gems_data(trainsize):
     return lifted_data, time_domain
 
 
-def weights_time_decay(time_domain, sigma=2):
-    """Construct weights based on the time (smaller time, greater weight):
-
-    w_j = σ^(t_j / t_{k-1}),  j = 0, 1, ..., k - 1 = trainsize - 1.
-
-    Parameters
-    ----------
-    time_domain : (trainsize,) ndarray
-        Time domain corresponding to the training snapshots.
-
-    sigma : float > 1
-        Base of exponential.
-
-    Returns
-    -------
-    w : (trainsize,) ndarray
-        Snapshot weights.
-    """
-    t = time_domain - time_domain[0]
-    return sigma**(-t/t[-1])
-
-
-def weights_gaussian(training_data, sigma=1, k=None, kernelize=True):
-    """Construct weights based on the Gaussian kernel (spatial importance):
-
-    K(xi, xj) = exp(-||xi - xj||^2 / 2σ^2)
-
-    Parameters
-    ----------
-    training_data : (n,k) ndarray
-        Training snapshots, pre-processed except for mean shifting.
-
-    sigma : float > 0
-        Gaussian kernel spread hyperparameter.
-
-    k : int > 0 or None
-        Dimension of random projection to approximate distances.
-
-    kernelize : bool
-        If True, apply the Gaussian kernel. If False, use squared Euclidean
-        distances (no kernel).
-    """
-    # If k is given, randomly project the data to r dimensions.
-    if k is not None:
-        M = np.random.standard_normal((training_data.shape[0], k))
-        X = (M.T @ training_data).T
-    else:
-        X = training_data.T
-        k = 1
-
-    # Calculate the kernel matrix and the resulting weights.
-    distances = sp.distance.pdist(X, "sqeuclidean") / k
-    if kernelize:
-        distances = np.exp(-distances/(2*sigma**2))
-    K = sp.distance.squareform(distances)
-    return np.mean(K, axis=1)
-
-
-def scale_and_save_data(trainsize, lifted_data, time_domain, weights=None):
+def scale_and_save_data(trainsize, lifted_data, time_domain):
     """Scale lifted snapshots (by variable) and save the scaled snapshots.
 
     Parameters
@@ -126,9 +67,6 @@ def scale_and_save_data(trainsize, lifted_data, time_domain, weights=None):
 
     time_domain : (k>trainsize,) ndarray
         The time domain corresponding to the lifted snapshots.
-
-    weights : (trainsize,) ndarray or None
-        If given, weight the mean shift and the resulting snapshots.
 
     Returns
     -------
@@ -147,19 +85,8 @@ def scale_and_save_data(trainsize, lifted_data, time_domain, weights=None):
 
     # Shift the scaled data by the mean snapshot.
     with utils.timed_block(f"Shifting {trainsize:d} scaled snapshots by mean"):
-        if weights is None:
-            qbar = np.mean(training_data, axis=1)           # Standard mean
-            training_data -= qbar.reshape((-1,1))           # Shift by mean
-        else:
-            if isinstance(weights, str):
-                if weights == "temporal":
-                    weights = weights_time_decay(time_domain[:trainsize])
-                elif weights == "Gaussian":
-                    weights = weights_gaussian(training_data)
-            weights /= np.sum(weights)                      # Normalize weights
-            qbar = np.mean(training_data * weights, axis=1) # Weighted mean
-            training_data -= qbar.reshape((-1,1))           # Shift by mean
-            training_data *= weights                        # Weight snapshots
+        qbar = np.mean(training_data, axis=1)           # Standard mean
+        training_data -= qbar.reshape((-1,1))           # Shift by mean
 
     # Save the lifted, scaled training data.
     save_path = config.scaled_data_path(trainsize)

--- a/step2c_project.py
+++ b/step2c_project.py
@@ -102,10 +102,10 @@ def main(trainsize):
     utils.reset_logger(trainsize)
 
     # Load lifted, scaled snapshot data.
-    scaled_data, time_domain, _ = utils.load_scaled_data(trainsize)
+    scaled_data, time_domain, _, _ = utils.load_scaled_data(trainsize)
 
     # Load the POD basis.
-    V, scales = utils.load_basis(trainsize, None, None)
+    V, _, _ = utils.load_basis(trainsize, None)
 
     # Project and save the data.
     return project_and_save_data(scaled_data, time_domain, V)

--- a/step4_plot.py
+++ b/step4_plot.py
@@ -301,8 +301,9 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
         with utils.timed_block(f"Reconstructing results for {var}"):
             Vvar = dproc.getvar(var, V)
             gems_var = dproc.getvar(var, data_gems)
-            proj_var = dproc.unscale((Vvar @ data_proj) + qbar, scales, var)
-            pred_var = dproc.unscale((Vvar @ q_rom) + qbar, scales, var)
+            qbarvar = dproc.getvar(var, qbar)
+            proj_var = dproc.unscale((Vvar @ data_proj) + qbarvar, scales, var)
+            pred_var = dproc.unscale((Vvar @ q_rom) + qbarvar, scales, var)
 
         with utils.timed_block(f"Calculating error in {var}"):
             denom = np.abs(gems_var).max(axis=0)

--- a/step4_plot.py
+++ b/step4_plot.py
@@ -71,9 +71,13 @@ def simulate_rom(trainsize, r, regs, steps=None):
     t : (nt,) ndarray
         Time domain corresponding to the ROM outputs.
 
-    V : (config*NUM_ROMVARS*config.DOF,r) ndarray
+    V : (NUM_ROMVARS*DOF,r) ndarray
         POD basis used to project the training data (and for reconstructing
         the full-order scaled predictions).
+
+    qbar : (NUM_ROMVARS*DOF,) ndarray
+        Mean snapshot that the training data was shifted by after scaling
+        but before projection.
 
     scales : (NUM_ROMVARS,4) ndarray
         Information for how the data was scaled. See data_processing.scale().
@@ -83,7 +87,7 @@ def simulate_rom(trainsize, r, regs, steps=None):
     """
     # Load the time domain, basis, initial conditions, and trained ROM.
     t = utils.load_time_domain(steps)
-    V, scales = utils.load_basis(trainsize, r)
+    V, qbar, scales = utils.load_basis(trainsize, r)
     Q_, _, _ = utils.load_projected_data(trainsize, r)
     rom = utils.load_rom(trainsize, r, regs)
     λ1, λ2 = regs
@@ -93,10 +97,10 @@ def simulate_rom(trainsize, r, regs, steps=None):
                            f"λ1={λ1:.0f}, λ2={λ2:.0f} over full time domain"):
         q_rom = rom.predict(Q_[:,0], t, config.U, method="RK45")
 
-    return t, V, scales, q_rom
+    return t, V, qbar, scales, q_rom
 
 
-def get_traces(locs, data, V=None, scales=None):
+def get_traces(locs, data, V=None, qbar=None, scales=None):
     """Reconstruct time traces from data, unprojecting and unscaling if needed.
 
     Parameters
@@ -111,6 +115,11 @@ def get_traces(locs, data, V=None, scales=None):
     V : (config.DOF*config.NUM_ROMVARS,r) ndarray or None
         Rank-r POD basis. Only needed if `data` is low-dimensional ROM output.
 
+    qbar : (NUM_ROMVARS*DOF,) ndarray
+        Mean snapshot that the training data was shifted by after scaling
+        but before projection. Only needed if `data` is low-dimensional ROM
+        output.
+
     scales : (config.NUM_ROMVARS,4) ndarray or None
         Information for how the data was scaled (see data_processing.scale()).
         Only needed if `data` is low-dimensional ROM output.
@@ -120,13 +129,14 @@ def get_traces(locs, data, V=None, scales=None):
     traces : (l,nt) ndarray
         The specified time traces.
     """
-    if V is not None and scales is not None:
-        return dproc.unscale(V[locs] @ data, scales)
+    if V is not None and qbar is not None and scales is not None:
+        qbar = qbar.reshape((-1,1))
+        return dproc.unscale((V[locs] @ data) + qbar[locs,:], scales)
     else:
         return data[locs]
 
 
-def get_feature(key, data, V=None, scales=None):
+def get_feature(key, data, V=None, qbar=None, scales=None):
     """Reconstruct a spatial statistical feature from data, unprojecting and
     unscaling if needed.
 
@@ -135,14 +145,19 @@ def get_feature(key, data, V=None, scales=None):
     key : str
         Which statistical feature to calculate (T_mean, CH4_sum, etc.)
 
-    data : (r,nt) or (config.DOF*config.NUM_ROMVARS,nt) ndarray
+    data : (r,nt) or (DOF*NUM_ROMVARS,nt) ndarray
         Data from which to extract the features, either the output of a ROM
         or a high-dimensional data set.
 
-    V : (config.DOF*config.NUM_ROMVARS,r) ndarray or None
+    V : (DOF*NUM_ROMVARS,r) ndarray or None
         Rank-r POD basis. Only needed if data is low-dimensional ROM output.
 
-    scales : (config.NUM_ROMVARS,2) ndarray or None
+    qbar : (NUM_ROMVARS*DOF,) ndarray
+        Mean snapshot that the training data was shifted by after scaling
+        but before projection. Only needed if `data` is low-dimensional ROM
+        output.
+
+    scales : (NUM_ROMVARS,2) ndarray or None
         Information for how the data was scaled (see data_processing.scale()).
         Only needed if `data` is low-dimensional ROM output.
 
@@ -153,8 +168,10 @@ def get_feature(key, data, V=None, scales=None):
     """
     var, action = key.split('_')
     print(f"{action}({var})", end='..', flush=True)
-    if V is not None and scales is not None:
-        variable = dproc.unscale(dproc.getvar(var, V) @ data, scales, var)
+    if V is not None and qbar is not None and scales is not None:
+        qbar = qbar.reshape((-1,1))
+        data_scaled = (dproc.getvar(var, V) @ data) + dproc.getvar(var, qbar)
+        variable = dproc.unscale(data_scaled, scales, var)
     else:
         variable = dproc.getvar(var, data)
     return eval(f"variable.{action}(axis=0)")
@@ -179,7 +196,7 @@ def point_traces(trainsize, r, regs, elems, cutoff=60000):
         Regularization hyperparameters used to train the ROM.
 
     elems : list(int) or ndarray(int)
-        Indices in the spatial domain at which to compute the time traces.
+        Indices in the spatial domain at which to compute the point traces.
 
     cutoff : int
         Numer of time steps to plot.
@@ -200,12 +217,12 @@ def point_traces(trainsize, r, regs, elems, cutoff=60000):
         traces_gems = dproc.lift(data[:,:cutoff])
 
     # Load and simulate the ROM.
-    t, V, scales, q_rom = simulate_rom(trainsize, r, regs, cutoff)
+    t, V, qbar, scales, q_rom = simulate_rom(trainsize, r, regs, cutoff)
 
     # Reconstruct and rescale the simulation results.
     simend = q_rom.shape[1]
     with utils.timed_block("Reconstructing simulation results"):
-        traces_rom = dproc.unscale(V[elems] @ q_rom, scales)
+        traces_rom = get_traces(elems, q_rom, V, qbar, scales)
 
     # Save a figure for each variable.
     xticks = np.arange(t[0], t[-1]+.001, .002)
@@ -260,7 +277,8 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
         Numer of time steps to plot.
     """
     # Load and simulate the ROM.
-    t, V, scales, q_rom = simulate_rom(trainsize, r, regs, cutoff)
+    t, V, qbar, scales, q_rom = simulate_rom(trainsize, r, regs, cutoff)
+    qbar = qbar.reshape((-1,1))
 
     # Load and lift the true results.
     data, _ = utils.load_gems_data(cols=cutoff)
@@ -270,9 +288,9 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
 
     # Shift and project the data (unscaling done later by chunk).
     with utils.timed_block("Projecting GEMS data to POD subspace"):
-        data_shifted, _ = dproc.scale(data_gems.copy(), scales)
-        data_proj = V.T @ data_shifted
-        del data_shifted
+        data_scaled, _ = dproc.scale(data_gems.copy(), scales)
+        data_proj = V.T @ (data_scaled - qbar)
+        del data_scaled
 
     # Initialize the figure.
     fig, axes = plt.subplots(3, 3, figsize=(12,6), sharex=True)
@@ -283,8 +301,8 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
         with utils.timed_block(f"Reconstructing results for {var}"):
             Vvar = dproc.getvar(var, V)
             gems_var = dproc.getvar(var, data_gems)
-            proj_var = dproc.unscale(Vvar @ data_proj, scales, var)
-            pred_var = dproc.unscale(Vvar @ q_rom, scales, var)
+            proj_var = dproc.unscale((Vvar @ data_proj) + qbar, scales, var)
+            pred_var = dproc.unscale((Vvar @ q_rom) + qbar, scales, var)
 
         with utils.timed_block(f"Calculating error in {var}"):
             denom = np.abs(gems_var).max(axis=0)
@@ -388,7 +406,7 @@ def spatial_statistics(trainsize, r, regs):
     keys = np.reshape(keys, (4,2), order='F')
 
     # Load and simulate the ROM.
-    t, V, scales, q_rom = simulate_rom(trainsize, r, regs)
+    t, V, qbar, scales, q_rom = simulate_rom(trainsize, r, regs)
 
     # Initialize the figure.
     fig, axes = plt.subplots(keys.shape[0], keys.shape[1],
@@ -397,7 +415,7 @@ def spatial_statistics(trainsize, r, regs):
     # Calculate and plot the results.
     for ax,key in zip(axes.flat, keys.flat):
         with utils.timed_block(f"Reconstructing"):
-            feature_rom = get_feature(key, q_rom, V, scales)
+            feature_rom = get_feature(key, q_rom, V, qbar, scales)
         ax.plot(t, feature_gems[key], lw=1, **config.GEMS_STYLE)
         ax.plot(t[:q_rom.shape[1]], feature_rom, lw=1, **config.ROM_STYLE)
         ax.axvline(t[trainsize], color='k')


### PR DESCRIPTION
This PR automates subtracting a mean vector **q**bar before the POD basis is computed. That is, the POD representation of the (lifted, scaled) data is **q**(t) = **Vq**hat(t) + **q**bar, and the previous approach was **q**(t) = **Vq**hat(t).