### PR TITLE
Set up Linting + Lint Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint install
+
+
+PYTHON = python3
+LINTER = flake8
+INSTALLER = pip install --user -r
+
+
+lint:
+	$(PYTHON) -m $(LINTER) *.py
+
+
+install:
+	$(PYTHON) -m $(INSTALLER) requirements.txt
+

--- a/chemistry_conversions.py
+++ b/chemistry_conversions.py
@@ -9,8 +9,6 @@ See data_processing.lift() and data_processing.unlift().
 * temperature(): compute temperature from pressure, specific volume,
     and species molar concentrations.
 """
-import numpy as np
-
 import config
 
 
@@ -29,7 +27,7 @@ def _check_shapes(species, *args):
             raise ValueError("species must all have same shape")
     for other in args:
         if other.shape != _shape:
-            raise ValueError(f"inputs not aligned with species")
+            raise ValueError("inputs not aligned with species")
 
 
 # Mass fractions to/from molar concentrations =================================
@@ -165,4 +163,3 @@ def temperature(p, xi, molars):
 
     # Compute temperature (ideal gas law).
     return p * xi / R_specific
-

--- a/config.py
+++ b/config.py
@@ -37,13 +37,16 @@ DIM_PREFIX = "r"                            # Prefix for ROM dimension folders.
 ROM_PREFIX = "rom"                          # Prefix for trained ROM files.
 REG_PREFIX = "reg"                          # Prefix for regularization values.
 
+
 def TRNFMT(k):
     """String format for trianing sizes."""
     return f"{TRN_PREFIX}{k:05d}"
 
+
 def DIMFMT(r):
     """String format for ROM dimensions."""
     return f"{DIM_PREFIX}{r:03d}"
+
 
 def REGFMT(λs):
     """String format for the regularization parmeters."""
@@ -51,14 +54,17 @@ def REGFMT(λs):
         raise ValueError(f"invalid regularization parameters {λs}")
     return REG_PREFIX + "_".join(f"{λ:06.0f}" for λ in λs)
 
+
 # Domain geometry -------------------------------------------------------------
 
 DOF = 38523                                 # Spatial degrees of freedom.
 
-MONITOR_LOCATIONS = [36915,                 # Index of monitor location 1.
-                     37886,                 # Index of monitor location 2.
-                     36443,                 # Index of monitor location 3.
-                      6141]                 # Index of monitor location 4.
+MONITOR_LOCATIONS = [
+    36915,                                  # Index of monitor location 1.
+    37886,                                  # Index of monitor location 2.
+    36443,                                  # Index of monitor location 3.
+    6141,                                   # Index of monitor location 4.
+]
 
 DT = 1e-7                                   # Temporal resolution of snapshots.
 
@@ -77,6 +83,7 @@ NUM_SPECIES = len(SPECIES)                  # Number of chemical species.
 NUM_GEMSVARS = len(GEMS_VARIABLES)          # Number of GEMS variables.
 NUM_ROMVARS = len(ROM_VARIABLES)            # Number of learning variables.
 
+
 # Chemistry constants ---------------------------------------------------------
 
 MOLAR_MASSES = [16.04,                      # Molar mass of CH4 [kg/kmol].
@@ -86,13 +93,18 @@ MOLAR_MASSES = [16.04,                      # Molar mass of CH4 [kg/kmol].
 
 R_UNIVERSAL = 8.3144598                     # Univ. gas constant [J/(mol K)].
 
+
 # ROM Structure ---------------------------------------------------------------
 
 MODELFORM = "cAHB"                          # ROM operators to be inferred.
 
+
 # Input function (Pressure oscillation) ---------------------------------------
 
-U = lambda t: 1e6*(1 + 0.1*np.sin(np.pi*1e4*t))
+def U(t):
+    """Input function for pressure oscillation."""
+    return 1e6*(1 + 0.1*np.sin(np.pi*1e4*t))
+
 
 # Matplotlib plot customization -----------------------------------------------
 
@@ -101,30 +113,33 @@ plt.rc("text", usetex=True)                 # Use LaTeX fonts.
 plt.rc("font", family="serif")              # Serif axis labels.
 plt.rc("legend", edgecolor="none",          # No borders around legends.
                  frameon=False)             # No legend backgrounds.
+plt.rc("axes", linewidth=.5)                # Thinner plot borders.
 
 # Names of the learning variables (for LaTeX fonts).
-VARTITLES = {  "p": "Pressure",
-              "vx": "$x$-velocity",
-              "vy": "$y$-velocity",
-               "T": "Temperature",
-              "xi": r"$\xi$",
-             "CH4": "CH$_4$",
-              "O2": "O$_2$",
-             "H2O": "H$_2$O",
-             "CO2": "CO$_2$",
-            }
+VARTITLES = {
+    "p": "Pressure",
+    "vx": "$x$-velocity",
+    "vy": "$y$-velocity",
+    "T": "Temperature",
+    "xi": r"$\xi$",
+    "CH4": "CH$_4$",
+    "O2": "O$_2$",
+    "H2O": "H$_2$O",
+    "CO2": "CO$_2$",
+}
 
 # Units of the learning variables (for LaTeX fonts).
-VARUNITS = {   "p": "Pa",
-              "vx": "m/s",
-              "vy": "m/s",
-               "T": "K",
-              "xi": "m$^3$/kg",
-             "CH4": "kmol/m$^3$",
-              "O2": "kmol/m$^3$",
-             "H2O": "kmol/m$^3$",
-             "CO2": "kmol/m$^3$",
-            }
+VARUNITS = {
+    "p": "Pa",
+    "vx": "m/s",
+    "vy": "m/s",
+    "T": "K",
+    "xi": "m$^3$/kg",
+    "CH4": "kmol/m$^3$",
+    "O2": "kmol/m$^3$",
+    "H2O": "kmol/m$^3$",
+    "CO2": "kmol/m$^3$",
+}
 
 # Learning variable titles with units (for LaTeX fonts).
 VARLABELS = {v: f"{VARTITLES[v]} [{VARUNITS[v]}]" for v in ROM_VARIABLES}
@@ -139,6 +154,7 @@ ROM_STYLE = dict(linestyle="--",            # Line style for ROM time traces.
 
 # =============================================================================
 # DO NOT MODIFY ===============================================================
+
 
 def _makefolder(*args):
     """Join arguments into a path to a folder. If the folder doesn't exist,
@@ -233,8 +249,8 @@ def rom_snapshot_path(trainsize, num_modes, regs):
     derived from a ROM trained with `trainsize` snapshots, `num_modes` POD
     modes, and regularization parameters of `regs`, for use with Tecplot.
     """
-    return _makefolder(tecplot_path(),
-                     f"{TRNFMT(trainsize)}_{DIMFMT(num_modes)}_{REGFMT(regs)}")
+    filename = f"{TRNFMT(trainsize)}_{DIMFMT(num_modes)}_{REGFMT(regs)}"
+    return _makefolder(tecplot_path(), filename)
 
 
 # Validation ------------------------------------------------------------------

--- a/data_processing.py
+++ b/data_processing.py
@@ -9,8 +9,6 @@
 import logging
 import numpy as np
 
-import rom_operator_inference as roi
-
 import config
 import chemistry_conversions as chem
 
@@ -88,10 +86,10 @@ def _varslice(varname, datasize):
     datasize : int
         Number of rows (2D) or entries (1D) of data, e.g., data.shape[0].
         Must be a multiple of config.NUM_ROMVARS.
-    
+
     varname : str
         An entry of config.ROM_VARIABLES indicating the variable to get/set.
-    
+
     Returns
     -------
     s : slice
@@ -103,7 +101,7 @@ def _varslice(varname, datasize):
         raise ValueError("data cannot be split evenly"
                          f" into {config.NUM_ROMVARS} chunks")
     return slice(varindex*chunksize, (varindex+1)*chunksize)
-    
+
 
 def getvar(varname, data):
     """Extract the specified variable from the given data."""

--- a/inventory.py
+++ b/inventory.py
@@ -9,7 +9,12 @@ import config
 
 
 _s = "    "                                 # Indentation space.
-_sglob = lambda x: sorted(glob.glob(x))     # Sorted glob().
+
+
+def _sglob(x):
+    """Sorted glob()."""
+    return sorted(glob.glob(x))
+
 
 # Regular expresssions --------------------------------------------------------
 
@@ -17,13 +22,16 @@ _trnpat = re.compile(fr".*{config.TRN_PREFIX}(\d+)")
 _dimpat = re.compile(fr".*{config.DIM_PREFIX}(\d+)")
 _regpat = re.compile(fr".*{config.ROM_PREFIX}_{config.REG_PREFIX}([\d_]+)\.h5")
 
+
 def _get_trn(foldername):
     result = _trnpat.findall(foldername)
     return int(result[0]) if result else None
 
+
 def _get_dim(foldername):
     result = _dimpat.findall(foldername)
     return int(result[0]) if result else None
+
 
 def _get_regs(filename):
     result = _regpat.findall(filename)
@@ -74,18 +82,18 @@ def main():
             print(f"{_s}* GEMS data file ({basename})")
         elif basename == config.FEATURES_FILE:
             print(f"{_s}* Features file ({basename})")
-        else:      
+        else:
             print(f"{_s}* {basename}")
     for folder in _sglob(os.path.join(config.BASE_FOLDER,
                                       config.TRN_PREFIX + '*')):
         print_trainsize_folder(folder)
-    
+
 
 if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} [--help]"""
 
     # Parse "arguments" and call main routine.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,10 @@
 [flake8]
 ignore =
+    D,
     E226,
     E231
 per-file-ignores =
-    config.py: E127
+    config.py: E127,
     step4_plot.py: F841
 max-line-length = 90
 statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ ignore =
     E226,
     E231
 per-file-ignores =
-    config.py: E127,
-    step4_plot.py: F841
+    config.py: E127
 max-line-length = 90
 statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+ignore =
+    E226,
+    E231
+per-file-ignores =
+    config.py: E127
+    step4_plot.py: F841
+max-line-length = 90
+statistics = True

--- a/step1_unpack.py
+++ b/step1_unpack.py
@@ -117,15 +117,15 @@ def _read_tar_and_save_data(tfile, start, stop, parallel=True):
     with utils.timed_block(f"Saving snapshots {start}-{stop} to HDF5"):
         with h5py.File(save_path, 'a') as hf:
             hf["data"][:,start:stop] = gems_data
-            hf["time"][  start:stop] = times
+            hf["time"][start:stop] = times
     print(f"Data saved to {save_path}.", flush=True)
     if parallel:
         lock.release()  # Let other processes resume.
 
 
-def _globalize_lock(l):
+def _globalize_lock(L):
     global lock
-    lock = l
+    lock = L
 
 
 def main(data_folder, overwrite=False, serial=False):
@@ -188,9 +188,8 @@ def main(data_folder, overwrite=False, serial=False):
         with h5py.File(save_path, 'w') as hf:
             hf.create_dataset("data", shape=(config.DOF*config.NUM_GEMSVARS,
                                              num_snapshots),
-                                      dtype=np.float64)
-            hf.create_dataset("time", shape=(num_snapshots,),
-                                      dtype=np.float64)
+                              dtype=np.float64)
+            hf.create_dataset("time", shape=(num_snapshots,), dtype=np.float64)
     logging.info(f"Data file initialized as {save_path}.")
 
     # Read the files in chunks.
@@ -209,7 +208,7 @@ if __name__ == '__main__':
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} DATAFOLDER [--overwrite] [--serial]"""
 

--- a/step2_preprocess.py
+++ b/step2_preprocess.py
@@ -83,7 +83,7 @@ def main(trainsize, num_modes):
             raise utils.DataNotFoundError("not enough saved basis vectors")
         num_modes = basis.shape[1]      # Use larger basis size if available.
 
-    except utils.DataNotFoundError as e:
+    except utils.DataNotFoundError:
         # Compute and save the (randomized) SVD from the training data.
         basis = step2b.compute_and_save_pod_basis(num_modes,
                                                   training_data, scales)
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} TRAINSIZE MODES"""
     parser.add_argument("trainsize", type=int,

--- a/step2a_transform.py
+++ b/step2a_transform.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} TRAINSIZE [...]"""
     parser.add_argument("trainsize", type=int, nargs='+',

--- a/step2b_basis.py
+++ b/step2b_basis.py
@@ -61,7 +61,7 @@ def compute_and_save_pod_basis(num_modes, training_data, qbar, scales):
 
     # Save the POD basis.
     save_path = config.basis_path(training_data.shape[1])
-    with utils.timed_block(f"Saving POD basis"):
+    with utils.timed_block("Saving POD basis"):
         with h5py.File(save_path, 'w') as hf:
             hf.create_dataset("basis", data=V)
             hf.create_dataset("svdvals", data=svdvals)
@@ -94,7 +94,7 @@ def compute_and_save_all_svdvals(training_data):
     # Save the POD basis.
     save_path = config.basis_path(training_data.shape[1])
     save_path = save_path.replace(config.BASIS_FILE, "svdvals.h5")
-    with utils.timed_block(f"Saving singular values"):
+    with utils.timed_block("Saving singular values"):
         with h5py.File(save_path, 'w') as hf:
             hf.create_dataset("svdvals", data=svdvals)
     logging.info(f"Singular values saved to {save_path}.\n")
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} TRAINSIZE MODES"""
     parser.add_argument("trainsize", type=int,

--- a/step2c_project.py
+++ b/step2c_project.py
@@ -76,7 +76,7 @@ def project_and_save_data(Q, t, V):
 
     # Save the projected training data.
     save_path = config.projected_data_path(Q.shape[1])
-    with utils.timed_block(f"Saving projected data"):
+    with utils.timed_block("Saving projected data"):
         with h5py.File(save_path, 'w') as hf:
             hf.create_dataset("data", data=Q_)
             hf.create_dataset("ddt", data=Qdot_)
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} TRAINSIZE"""
     parser.add_argument("trainsize", type=int,

--- a/step3_train.py
+++ b/step3_train.py
@@ -268,8 +268,9 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
 
             # Calculate integrated relative errors in the reduced space.
             if q_rom.shape[1] > trainsize:
-                errors[(λ1,λ2)] = roi.post.Lp_error(Q_, q_rom[:,:trainsize],
-                                                            t[:trainsize])[1]
+                errors[(λ1,λ2)] = roi.post.Lp_error(Q_,
+                                                    q_rom[:,:trainsize],
+                                                    t[:trainsize])[1]
 
     # Choose and save the ROM with the least error.
     if not errors_pass:
@@ -402,7 +403,7 @@ def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
     utils.reset_logger(trainsize)
 
     # Parse aguments.
-    d = check_lstsq_size(trainsize, r)
+    check_lstsq_size(trainsize, r)
     log10regs = np.log10(check_regs(regs))
 
     # Load training data.
@@ -456,13 +457,12 @@ def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
         logging.info(message)
 
 
-
 # =============================================================================
 if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} --single TRAINSIZE R REG1 REG2
         python3 {__file__} --gridsearch TRAINSIZE R REG1 ... REG6

--- a/step4_plot.py
+++ b/step4_plot.py
@@ -415,7 +415,7 @@ def spatial_statistics(trainsize, r, regs):
 
     # Calculate and plot the results.
     for ax,key in zip(axes.flat, keys.flat):
-        with utils.timed_block(f"Reconstructing"):
+        with utils.timed_block("Reconstructing"):
             feature_rom = get_feature(key, q_rom, V, qbar, scales)
         ax.plot(t, feature_gems[key], lw=1, **config.GEMS_STYLE)
         ax.plot(t[:q_rom.shape[1]], feature_rom, lw=1, **config.ROM_STYLE)
@@ -444,7 +444,8 @@ def spatial_statistics(trainsize, r, regs):
                       f"_{config.DIMFMT(r)}"
                       f"_{config.REGFMT(regs)}.pdf")
 
-# =============================================================================
+
+# Main routine ================================================================
 
 def main(trainsize, r, regs, elems=None, plotPointTrace=False,
          plotRelativeErrors=False, plotSpatialStatistics=False):
@@ -490,7 +491,7 @@ if __name__ == "__main__":
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
         python3 {__file__} --point-traces TRAINSIZE MODES REG1 REG2
                            [--location L [...]]
@@ -513,7 +514,7 @@ if __name__ == "__main__":
                              "monitoring locations")
     parser.add_argument("--relative-errors", action="store_true",
                         help="plot relative errors in time, averaged over "
-                              "the spatial domain")
+                             "the spatial domain")
     parser.add_argument("--spatial-statistics", action="store_true",
                         help="plot spatial averages and species integrals")
 

--- a/step4_plot.py
+++ b/step4_plot.py
@@ -173,7 +173,7 @@ def get_feature(key, data, V=None, qbar=None, scales=None):
         data_scaled = (dproc.getvar(var, V) @ data) + dproc.getvar(var, qbar)
         variable = dproc.unscale(data_scaled, scales, var)
     else:
-        variable = dproc.getvar(var, data)
+        variable = dproc.getvar(var, data)          # noqa
     return eval(f"variable.{action}(axis=0)")
 
 

--- a/step5_export.py
+++ b/step5_export.py
@@ -51,6 +51,8 @@ import data_processing as dproc
 import step4_plot as step4
 
 
+# header = HEADER.format(varnames, timeindex, solutiontime,
+#                        num_nodes, DOF, num_vars, datatypes)
 HEADER = """TITLE = "Combustion GEMS 2D Nonintrusive ROM"
 VARIABLES="x"
 "y"
@@ -61,8 +63,7 @@ Nodes={:d}, Elements={:d}, ZONETYPE=FEQuadrilateral
 DATAPACKING=BLOCK
 VARLOCATION=([3-{:d}]=CELLCENTERED)
 DT=({:s})
-""" # header = HEADER.format(varnames, timeindex, solutiontime,
-    #                        num_nodes, DOF, num_vars, datatypes)
+"""
 
 NCOLS = 4
 
@@ -134,7 +135,7 @@ def main(timeindices, variables=None, snaptype=("gems", "rom", "error"),
         grid_data = grid[headersize:].split()
         x = grid_data[:num_nodes]
         y = grid_data[num_nodes:2*num_nodes]
-        cell_volume = grid_data[2*num_nodes:3*num_nodes]
+        # cell_volume = grid_data[2*num_nodes:3*num_nodes]
         connectivity = grid_data[3*num_nodes:]
 
     # Extract full-order data if needed.
@@ -143,7 +144,7 @@ def main(timeindices, variables=None, snaptype=("gems", "rom", "error"),
         with utils.timed_block("Lifting selected snapshots of GEMS data"):
             lifted_data = dproc.lift(gems_data)
             true_snaps = np.concatenate([dproc.getvar(v, lifted_data)
-                                                        for v in variables])
+                                         for v in variables])
     # Simulate ROM if needed.
     if ("rom" in snaptype) or ("error" in snaptype):
         t, V, scales, q_rom = step4.simulate_rom(trainsize, r, reg,
@@ -235,7 +236,7 @@ def temperature_average(trainsize, r, reg, cutoff=60000):
         grid_data = grid[headersize:].split()
         x = grid_data[:num_nodes]
         y = grid_data[num_nodes:2*num_nodes]
-        cell_volume = grid_data[2*num_nodes:3*num_nodes]
+        # cell_volume = grid_data[2*num_nodes:3*num_nodes]
         connectivity = grid_data[3*num_nodes:]
 
     # Compute full-order time-averaged temperature from GEMS data.
@@ -323,7 +324,7 @@ def basis(trainsize, r, variables=None):
         grid_data = grid[headersize:].split()
         x = grid_data[:num_nodes]
         y = grid_data[num_nodes:2*num_nodes]
-        cell_volume = grid_data[2*num_nodes:3*num_nodes]
+        # cell_volume = grid_data[2*num_nodes:3*num_nodes]
         connectivity = grid_data[3*num_nodes:]
 
     # Load the basis and extract desired variables.
@@ -364,7 +365,7 @@ if __name__ == '__main__':
     # Set up command line argument parsing.
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
-                        formatter_class=argparse.RawDescriptionHelpFormatter)
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} -h
         python3 {__file__} (gems | rom | error)
                                 --timeindex T [...]

--- a/test_data_processing.py
+++ b/test_data_processing.py
@@ -1,7 +1,5 @@
 # test_data_processing.py
 """Run basic tests for data_processing.py."""
-import h5py
-import time
 import logging
 import numpy as np
 

--- a/utils.py
+++ b/utils.py
@@ -16,7 +16,8 @@ except ModuleNotFoundError:
     raise
 if roi.__version__ != "1.2.1":
     raise ModuleNotFoundError("rom-operator-inference version 1.2.1 required "
-                         "(python3 -m pip install --user -r requirements.txt)")
+                              "(python3 -m pip install --user "
+                              "-r requirements.txt)")
 
 import config
 
@@ -217,13 +218,13 @@ def load_scaled_data(trainsize):
         with h5py.File(data_path, 'r') as hf:
             # Check data shapes.
             if hf["data"].shape != (config.NUM_ROMVARS*config.DOF, trainsize):
-                raise RuntimeError(f"data set 'data' has incorrect shape")
+                raise RuntimeError("data set 'data' has incorrect shape")
             if hf["time"].shape != (trainsize,):
-                raise RuntimeError(f"data set 'time' has incorrect shape")
+                raise RuntimeError("data set 'time' has incorrect shape")
             if hf["mean"].shape != (hf["data"].shape[0],):
                 raise RuntimeError("data set 'mean' has incorrect shape")
             if hf["scales"].shape != (config.NUM_ROMVARS, 2):
-                raise RuntimeError(f"data set 'scales' has incorrect shape")
+                raise RuntimeError("data set 'scales' has incorrect shape")
 
             # Load and return the data.
             return (hf["data"][:,:], hf["time"][:],
@@ -312,11 +313,11 @@ def load_projected_data(trainsize, r):
             if rmax < r:
                 raise ValueError(f"basis only has {rmax} columns")
             if hf["data"].shape[1] != trainsize:
-                raise RuntimeError(f"data set 'data' has incorrect shape")
+                raise RuntimeError("data set 'data' has incorrect shape")
             if hf["ddt"].shape != hf["data"].shape:
-                raise RuntimeError(f"data sets 'data' and 'ddt' not aligned")
+                raise RuntimeError("data sets 'data' and 'ddt' not aligned")
             if hf["time"].shape != (trainsize,):
-                raise RuntimeError(f"data set 'time' has incorrect shape")
+                raise RuntimeError("data set 'time' has incorrect shape")
 
             # Get the correct rows of the saved projection data.
             return hf["data"][:r], hf["ddt"][:r], hf["time"][:]


### PR DESCRIPTION
Set up linting with `flake8`, with settings configured in `setup.cfg`. Used linter to clean up the code.

Also added a `Makefile` for some nice shortcuts.
- `make lint` does the `flake8` linting for all `.py` files.
- `make install` installs dependencies with `pip`, reading from `requirements.txt`.