### PR TITLE
Add Functionality for Cubic Operator Inference

### DIFF
--- a/config.py
+++ b/config.py
@@ -61,8 +61,8 @@ def REGFMT(λs):
 def REGSTR(λs):
     """[x,y,z] -> 'λ1=x, λ2=y, λ3=z'"""
     if np.isscalar(λs):
-        return f"λ={λs}"
-    return ", ".join(f"λ{i+1}={λ}" for i,λ in enumerate(λs))
+        return f"λ={λs:5e}"
+    return ", ".join(f"λ{i+1}={λ:4e}" for i,λ in enumerate(λs))
 
 
 # Domain geometry -------------------------------------------------------------
@@ -94,7 +94,7 @@ NUM_GEMSVARS = len(GEMS_VARIABLES)          # Number of GEMS variables.
 NUM_ROMVARS = len(ROM_VARIABLES)            # Number of learning variables.
 
 
-# Chemistry constants ---------------------------------------------------------
+# Chemistry and physics -------------------------------------------------------
 
 MOLAR_MASSES = [16.04,                      # Molar mass of CH4 [kg/kmol].
                 32.0,                       # Molar mass of O2  [kg/kmol].
@@ -103,8 +103,6 @@ MOLAR_MASSES = [16.04,                      # Molar mass of CH4 [kg/kmol].
 
 R_UNIVERSAL = 8.3144598                     # Univ. gas constant [J/(mol K)].
 
-
-# Input function (Pressure oscillation) ---------------------------------------
 
 def U(t):
     """Input function for pressure oscillation."""

--- a/config.py
+++ b/config.py
@@ -8,6 +8,8 @@ preferably as an absolute path. Other global variables specify the naming
 conventions for the various data files.
 """
 import os
+import json
+import time
 import logging
 import numpy as np
 import matplotlib.pyplot as plt
@@ -28,6 +30,7 @@ GEMS_DATA_FILE = "gems.h5"                  # Name of GEMS data file.
 SCALED_DATA_FILE = "data_scaled.h5"         # Name of scaled data files.
 BASIS_FILE = "basis.h5"                     # Name of POD basis files.
 PROJECTED_DATA_FILE = "data_projected.h5"   # Name of projected data files.
+ROM_INDEX_FILE = "roms.json"                # Name of ROM index files.
 FEATURES_FILE = "statistical_features.h5"   # Name of statistical feature file.
 GRID_FILE = "grid.dat"                      # Name of Tecplot grid data file.
 LOG_FILE = "log.log"                        # Name of log files.
@@ -53,6 +56,13 @@ def REGFMT(λs):
     if np.isscalar(λs) or len(λs) != 2 or any(λ < 0 for λ in λs):
         raise ValueError(f"invalid regularization parameters {λs}")
     return REG_PREFIX + "_".join(f"{λ:06.0f}" for λ in λs)
+
+
+def REGSTR(λs):
+    """[x,y,z] -> 'λ1=x, λ2=y, λ3=z'"""
+    if np.isscalar(λs):
+        return f"λ={λs}"
+    return ", ".join(f"λ{i+1}={λ}" for i,λ in enumerate(λs))
 
 
 # Domain geometry -------------------------------------------------------------
@@ -92,11 +102,6 @@ MOLAR_MASSES = [16.04,                      # Molar mass of CH4 [kg/kmol].
                 44.01]                      # Molar mass of CO2 [kg/kmol].
 
 R_UNIVERSAL = 8.3144598                     # Univ. gas constant [J/(mol K)].
-
-
-# ROM Structure ---------------------------------------------------------------
-
-MODELFORM = "cAHB"                          # ROM operators to be inferred.
 
 
 # Input function (Pressure oscillation) ---------------------------------------
@@ -204,13 +209,67 @@ def projected_data_path(trainsize):
     return os.path.join(BASE_FOLDER, TRNFMT(trainsize), PROJECTED_DATA_FILE)
 
 
-def rom_path(trainsize, r, regs):
-    """Return the path to the file containing a ROM trained from
-    `trainsize` snapshots, projected to an `r`-dimensional space,
-    with regularization parameters `regs`.
+def rom_path(trainsize, r, regs, overwrite=False):
+    """Return the path to a file containing an OpInf ROM.
+
+    Parameters
+    ----------
+    trainsize : int
+        Number of snapshots used to train the ROM. This is also the number
+        of snapshots that were used when the POD basis (SVD) was computed.
+
+    r : int
+        Dimension of the ROM. Also the number of retained POD modes (left
+        singular vectors) used to project the training data.
+
+    regs : one, two, or three positive floats
+        Regularization hyperparameters used in the Operator Inference
+        least-squares problem for training the ROM.
+
+    overwrite : bool
+        If True, make a new ROM filename and overwrite any previous instances
+        with the same trainsize, r, and regs in the ROM index.
+
+    Returns
+    -------
+    filename : str
+        Path to a file to save an OpInf ROM to or load an OpInf ROM from.
     """
-    folder = _makefolder(BASE_FOLDER, TRNFMT(trainsize), DIMFMT(r))
-    return os.path.join(folder, f"{ROM_PREFIX}_{REGFMT(regs)}.h5")
+    rlabel = DIMFMT(r)
+    kfolder = _makefolder(BASE_FOLDER, TRNFMT(trainsize))
+    rfolder = _makefolder(kfolder, rlabel)
+    if np.isscalar(regs):
+        regs = [regs]
+    rregs = np.round(regs, 0)
+
+    # Find (or create) ROM index JSON file.
+    rom_json = os.path.join(kfolder, ROM_INDEX_FILE)
+    if not os.path.isfile(rom_json):
+        with open(rom_json, 'w') as outfile:
+            json.dump({}, outfile)
+
+    # Load and search ROM index file.
+    with open(rom_json, 'r') as infile:
+        rom_data = json.load(infile)
+    if rlabel not in rom_data:
+        rom_data[rlabel] = {}
+    for filename, reglabel in rom_data[rlabel].items():
+        if rregs.size == len(reglabel) and np.all(rregs == np.round(reglabel)):
+            romfile = os.path.join(rfolder, filename)
+            if not overwrite:
+                return romfile
+            else:
+                rom_data[rlabel].pop(filename)
+                if os.path.isfile(romfile):
+                    os.remove(romfile)
+                break
+
+    # Add an entry to the index if the ROM was not found (or superseded).
+    filename = time.strftime("%Y-%m-%d_%H:%M:%S") + ".h5"
+    rom_data[rlabel][filename] = regs
+    with open(rom_json, 'w') as outfile:
+        json.dump(rom_data, outfile, indent=4)
+    return os.path.join(rfolder, filename)
 
 
 def statistical_features_path():

--- a/inventory.py
+++ b/inventory.py
@@ -4,6 +4,8 @@
 import os
 import re
 import glob
+import json
+import shutil
 
 import config
 
@@ -20,44 +22,85 @@ def _sglob(x):
 
 _trnpat = re.compile(fr".*{config.TRN_PREFIX}(\d+)")
 _dimpat = re.compile(fr".*{config.DIM_PREFIX}(\d+)")
-_regpat = re.compile(fr".*{config.ROM_PREFIX}_{config.REG_PREFIX}([\d_]+)\.h5")
 
 
 def _get_trn(foldername):
+    """Extract the training size from the name of the folder."""
     result = _trnpat.findall(foldername)
     return int(result[0]) if result else None
 
 
 def _get_dim(foldername):
+    """Extract the ROM dimension from the name of the folder."""
     result = _dimpat.findall(foldername)
     return int(result[0]) if result else None
 
 
-def _get_regs(filename):
-    result = _regpat.findall(filename)
-    return [int(reg) for reg in result[0].split('_')] if result else None
-
-
 # Main routines ---------------------------------------------------------------
 
-def print_rom_folder(folder):
-    num_modes = _get_dim(folder)
-    print(f"{_s*2}ROM dimension = {num_modes} ({os.path.basename(folder)}/)")
-    prefix = f"{config.ROM_PREFIX}_{config.REG_PREFIX}"
-    romfiles = []
-    for dfile in _sglob(os.path.join(folder, "*.h5")):
-        basename = os.path.basename(dfile)
-        if basename.startswith(prefix):
-            romfiles.append(dfile)
-        else:
-            print(f"{_s*3}{basename}")
-    for dfile in romfiles:
-        regs = _get_regs(dfile)
-        print(f"{_s*3}* Trained ROM with λ1 = {regs[0]}, λ2 = {regs[1]}"
-              f" ({os.path.basename(dfile)})")
+def print_rom_index(folder, clean=False):
+    """Print and optionally reconcile a ROM index (config.ROM_INDEX_FILE).
+
+    Parameters
+    ----------
+    folder : str
+        Path to the folder to be examined, e.g,. BASE_FOLDER/k1000/.
+
+    clean : bool
+        If True, remove ROM files that are not listed in the ROM index and
+        remove ROM index entries that do not have corresponding ROM files.
+    """
+    # Load the ROM index if it exists.
+    rom_json = os.path.join(folder, config.ROM_INDEX_FILE)
+    if not os.path.isfile(rom_json):
+        rom_data = {}
+    else:
+        with open(rom_json, 'r') as infile:
+            rom_data = json.load(infile)
+        print(f"{_s*2}* ROM index ({os.path.basename(rom_json)})")
+
+    if clean:
+        # Remove items from the index if the corresponding file is missing.
+        missing_folders, missing_files = [], []
+        for rlabel in rom_data:
+            rfolder = os.path.join(folder, rlabel)
+            if not os.path.isdir(rfolder) or len(rom_data[rlabel]) == 0:
+                missing_folders.append(rlabel)
+            else:
+                for filename in rom_data[rlabel]:
+                    rom_file = os.path.join(rfolder, filename)
+                    if not os.path.isfile(rom_file):
+                        missing_files.append((rlabel, filename))
+        for rlabel in missing_folders:
+            rom_data.pop(rlabel)
+        for rlabel, filename in missing_files:
+            rom_data[rlabel].pop(filename)
+        with open(rom_json, 'w') as outfile:
+            json.dump(rom_data, outfile, indent=4)
+
+        # Remove any ROM files that aren't in the index.
+        for romfolder in _sglob(os.path.join(folder, "r???")):
+            if not os.path.isdir(romfolder):
+                continue
+            rlabel = os.path.basename(romfolder)
+            if rlabel not in rom_data:
+                shutil.rmtree(romfolder)
+            else:
+                for h5file in _sglob(os.path.join(romfolder, '*.h5')):
+                    if os.path.basename(h5file) not in rom_data[rlabel]:
+                        os.remove(os.path.join(romfolder, h5file))
+                if not any(os.scandir(romfolder)):
+                    os.rmdir(romfolder)
+
+    for rlabel in rom_data:
+        rfolder = os.path.join(folder, rlabel)
+        num_modes = _get_dim(rlabel)
+        print(f"{_s*2}ROM dimension = {num_modes} ({rlabel}/)")
+        for filename, regs in rom_data[rlabel].items():
+            print(f"{_s*3}* Trained ROM with {config.REGSTR(regs)}")
 
 
-def print_trainsize_folder(folder):
+def print_trainsize_folder(folder, clean=False):
     trainsize = _get_trn(folder)
     print(f"    Train size = {trainsize} ({os.path.basename(folder)}/)")
     for dfile in _sglob(os.path.join(folder, "*.h5")):
@@ -70,11 +113,10 @@ def print_trainsize_folder(folder):
             print(f"{_s*2}* Projected data ({basename})")
         else:
             print(f"{_s*2}* {basename}")
-    for romfolder in _sglob(os.path.join(folder, config.DIM_PREFIX + '*')):
-        print_rom_folder(romfolder)
+    print_rom_index(folder, clean=clean)
 
 
-def main():
+def main(clean=False):
     print(f"BASE FOLDER: ({config.BASE_FOLDER}/)")
     for dfile in _sglob(os.path.join(config.BASE_FOLDER, "*.h5")):
         basename = os.path.basename(dfile)
@@ -86,7 +128,7 @@ def main():
             print(f"{_s}* {basename}")
     for folder in _sglob(os.path.join(config.BASE_FOLDER,
                                       config.TRN_PREFIX + '*')):
-        print_trainsize_folder(folder)
+        print_trainsize_folder(folder, clean=clean)
 
 
 if __name__ == "__main__":
@@ -94,8 +136,14 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.usage = f""" python3 {__file__} [--help]"""
+    parser.usage = f""" python3 {__file__} --help
+    python3 {__file__} [--clean]"""
+
+    parser.add_argument("--clean", action="store_true",
+                        help="delete ROM files that are not listed in the "
+                             "directory and remove directory entries where "
+                             "the corresponding ROM file is missing")
 
     # Parse "arguments" and call main routine.
     args = parser.parse_args()
-    main()
+    main(clean=args.clean)

--- a/step2_preprocess.py
+++ b/step2_preprocess.py
@@ -42,7 +42,7 @@ import step2b_basis as step2b
 import step2c_project as step2c
 
 
-def main(trainsize, num_modes):
+def main(trainsize, num_modes, center=False):
     """Lift and scale the GEMS simulation data; compute a POD basis of the
     lifted, scaled snapshot training data; project the lifted, scaled snapshot
     training data to the subspace spanned by the columns of the POD basis V,
@@ -59,6 +59,10 @@ def main(trainsize, num_modes):
         The number of POD modes (left singular vectors) to use in the
         projection. This is the upper bound for the size of ROMs that
         can be trained with this data set.
+
+    center : bool
+        If True, center the scaled snapshots by the mean scaled snapshot
+        before computing the POD basis.
     """
     utils.reset_logger(trainsize)
 
@@ -72,7 +76,7 @@ def main(trainsize, num_modes):
         lifted_data, time = step2a.load_and_lift_gems_data(trainsize)
         training_data, qbar, scales = step2a.scale_and_save_data(trainsize,
                                                                  lifted_data,
-                                                                 time)
+                                                                 time, center)
         del lifted_data
 
     # STEP 2B: Get the POD basis from the lifted, scaled data -----------------
@@ -86,7 +90,7 @@ def main(trainsize, num_modes):
     except utils.DataNotFoundError:
         # Compute and save the (randomized) SVD from the training data.
         basis = step2b.compute_and_save_pod_basis(num_modes,
-                                                  training_data, scales)
+                                                  training_data, qbar, scales)
 
     # STEP 2C: Project data to the appropriate subspace -----------------------
     return step2c.project_and_save_data(training_data, time, basis)
@@ -99,12 +103,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
-        python3 {__file__} TRAINSIZE MODES"""
+        python3 {__file__} TRAINSIZE MODES [--center]"""
     parser.add_argument("trainsize", type=int,
                         help="number of snapshots in the training data")
     parser.add_argument("modes", type=int,
                         help="number of POD modes for projecting data")
+    parser.add_argument("--center", action="store_true",
+                        help="shift by the mean snapshot after scaling")
 
     # Do the main routine.
     args = parser.parse_args()
-    main(args.trainsize, args.modes)
+    main(args.trainsize, args.modes, center=args.center)

--- a/step2a_transform.py
+++ b/step2a_transform.py
@@ -54,7 +54,7 @@ def load_and_lift_gems_data(trainsize):
     return lifted_data, time_domain
 
 
-def scale_and_save_data(trainsize, lifted_data, time_domain):
+def scale_and_save_data(trainsize, lifted_data, time_domain, center=False):
     """Scale lifted snapshots (by variable) and save the scaled snapshots.
 
     Parameters
@@ -68,13 +68,17 @@ def scale_and_save_data(trainsize, lifted_data, time_domain):
     time_domain : (k>trainsize,) ndarray
         The time domain corresponding to the lifted snapshots.
 
+    center : bool
+        If True, center the scaled snapshots by the mean scaled snapshot
+        before computing the POD basis. Default False (no shift).
+
     Returns
     -------
     training_data : (NUM_ROMVARS*DOF, trainsize) ndarray
         Scaled, shifted snapshots to use as training data for the basis.
 
     qbar : (NUM_ROMVARS*DOF,) ndarray
-        Mean snapshot of the scaled training data.
+        Mean snapshot of the scaled training data. All zeros if center=False.
 
     scales : (NUM_ROMVARS,2) ndarray
         Info on how the snapshot data was scaled.
@@ -84,9 +88,12 @@ def scale_and_save_data(trainsize, lifted_data, time_domain):
         training_data, scales = dproc.scale(lifted_data[:,:trainsize].copy())
 
     # Shift the scaled data by the mean snapshot.
-    with utils.timed_block(f"Shifting {trainsize:d} scaled snapshots by mean"):
-        qbar = np.mean(training_data, axis=1)       # Compute mean snapshot.
-        training_data -= qbar.reshape((-1,1))       # Shift columns by mean.
+    if center:
+        with utils.timed_block(f"Shifting scaled snapshots by mean"):
+            qbar = np.mean(training_data, axis=1)   # Compute mean snapshot.
+            training_data -= qbar.reshape((-1,1))   # Shift columns by mean.
+    else:
+        qbar = np.zeros(training_data.shape[0])
 
     # Save the lifted, scaled training data.
     save_path = config.scaled_data_path(trainsize)
@@ -101,13 +108,17 @@ def scale_and_save_data(trainsize, lifted_data, time_domain):
     return training_data, qbar, scales
 
 
-def main(trainsizes):
+def main(trainsizes, center=False):
     """Lift and scale the GEMS simulation training data and save the results.
 
     Parameters
     ----------
     trainsizes : int or list(int)
         Number of snapshots to lift, scale, and save.
+
+    center : bool
+        If True, center the scaled snapshots by the mean scaled snapshot
+        before computing the POD basis.
     """
     utils.reset_logger()
 
@@ -120,7 +131,7 @@ def main(trainsizes):
     # Scale and save each subset of lifted data.
     for trainsize in trainsizes:
         utils.reset_logger(trainsize)
-        scale_and_save_data(trainsize, lifted_data, time_domain)
+        scale_and_save_data(trainsize, lifted_data, time_domain, center)
 
 
 # =============================================================================
@@ -130,10 +141,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.usage = f""" python3 {__file__} --help
-        python3 {__file__} TRAINSIZE [...]"""
+        python3 {__file__} TRAINSIZE [...] [--center]"""
     parser.add_argument("trainsize", type=int, nargs='+',
                         help="number of snapshots to lift, scale, and save")
+    parser.add_argument("--center", action="store_true",
+                        help="shift by the mean snapshot after scaling")
+
 
     # Do the main routine.
     args = parser.parse_args()
-    main(args.trainsize)
+    main(args.trainsize, center=args.center)

--- a/step2a_transform.py
+++ b/step2a_transform.py
@@ -89,7 +89,7 @@ def scale_and_save_data(trainsize, lifted_data, time_domain, center=False):
 
     # Shift the scaled data by the mean snapshot.
     if center:
-        with utils.timed_block(f"Shifting scaled snapshots by mean"):
+        with utils.timed_block("Shifting scaled snapshots by mean"):
             qbar = np.mean(training_data, axis=1)   # Compute mean snapshot.
             training_data -= qbar.reshape((-1,1))   # Shift columns by mean.
     else:
@@ -146,7 +146,6 @@ if __name__ == "__main__":
                         help="number of snapshots to lift, scale, and save")
     parser.add_argument("--center", action="store_true",
                         help="shift by the mean snapshot after scaling")
-
 
     # Do the main routine.
     args = parser.parse_args()

--- a/step2b_basis.py
+++ b/step2b_basis.py
@@ -25,7 +25,7 @@ import h5py
 import logging
 import scipy.linalg as la
 
-import rom_operator_inference as roi
+import rom_operator_inference as opinf
 
 import config
 import utils
@@ -55,9 +55,9 @@ def compute_and_save_pod_basis(num_modes, training_data, qbar, scales):
     """
     # Compute the randomized SVD from the training data.
     with utils.timed_block(f"Computing {num_modes}-component randomized SVD"):
-        V, svdvals = roi.pre.pod_basis(training_data, r=num_modes,
-                                       mode="randomized",
-                                       n_iter=15, random_state=42)
+        V, svdvals = opinf.pre.pod_basis(training_data, r=num_modes,
+                                         mode="randomized",
+                                         n_iter=15, random_state=42)
 
     # Save the POD basis.
     save_path = config.basis_path(training_data.shape[1])

--- a/step2c_project.py
+++ b/step2c_project.py
@@ -25,7 +25,7 @@ import h5py
 import logging
 import numpy as np
 
-import rom_operator_inference as roi
+import rom_operator_inference as opinf
 
 import config
 import utils
@@ -72,7 +72,7 @@ def project_and_save_data(Q, t, V):
     # Compute time derivative data.
     with utils.timed_block("Approximating time derivatives "
                            "of projected snapshots"):
-        Qdot_ = roi.pre.xdot_uniform(Q_, dt, order=4)
+        Qdot_ = opinf.pre.xdot_uniform(Q_, dt, order=4)
 
     # Save the projected training data.
     save_path = config.projected_data_path(Q.shape[1])

--- a/step3_train.py
+++ b/step3_train.py
@@ -7,7 +7,7 @@ Examples
 ## --single: train and save a single ROM for a given λ1, λ2.
 
 # Use 10,000 projected snapshots to learn a ROM of dimension r = 24
-# with regularization parameters λ1 = 400, λ2 = 21000.
+# with regularization hyperparameters λ1 = 400, λ2 = 21000.
 $ python3 step3_train.py --single 10000 24 400 21000
 
 ## --gridsearch: train over a grid of candidates for λ1 and λ2, saving
@@ -16,7 +16,7 @@ $ python3 step3_train.py --single 10000 24 400 21000
 # Use 20,000 projected snapshots to learn a ROM of dimension r = 40 and save
 # the one with the regularization resulting in the least training error and
 # for which the integrated POD modes stay within 150% of the training data in
-# magnitude for 60,000 time steps. For the regularization parameters, test
+# magnitude for 60,000 time steps. For the regularization hyperparameters, test
 # each point in the 4x5 logarithmically-spaced grid [500,9000]x[8000,10000]
 $ python3 step3_train.py --gridsearch 10000 40 5e2 9e3 4 8e3 1e4 5
                          --testsize 60000 --margin 1.5
@@ -28,8 +28,8 @@ $ python3 step3_train.py --gridsearch 10000 40 5e2 9e3 4 8e3 1e4 5
 # Use 10,000 projected snapshots to learn a ROM of dimension r = 30 and save
 # the one with the regularization resulting in the least training error and
 # for which the integrated POD modes stay within 150% of the training data in
-# magnitude for 60,000 time steps. For the regularization parameters, search
-# starting from λ1 = 300, λ2 = 7000.
+# magnitude for 60,000 time steps. For the regularization hyperparameters,
+# search starting from λ1 = 300, λ2 = 7000.
 $ python3 step3_train.py --minimize 10000 30 300 7000
                          --testsize 60000 --margin 1.5
 
@@ -41,7 +41,7 @@ Loading Results
 >>> import utils
 >>> trainsize = 10000       # Number of snapshots used as training data.
 >>> num_modes = 44          # Number of POD modes.
->>> regs = 1e4, 1e5         # Regularization parameters for Operator Inference.
+>>> regs = 1e4, 1e5         # OpInf regularization hyperparameters.
 >>> rom = utils.load_rom(trainsize, num_modes, reg)
 
 Command Line Arguments
@@ -83,25 +83,22 @@ def check_lstsq_size(trainsize, r, modelform="cAHB"):
     return d
 
 
-def check_regs(regs, num=2):
+def check_regs(regs):
     """Assure there are the correct number of non-negative regularization
     hyperparameters.
 
     Parameters
     ----------
-    regs : float > 0 or (num,) ndarray
-        Regularization hyperparameters. Must be non-negative.
-
-    num : int
-        Number of expected regularization hyperparameters.
+    regs : list/ndarray of two or three non-negative floats
+        Regularization hyperparameters.
     """
     if np.isscalar(regs):
         regs = [regs]
 
     # Check number of values.
     nregs = len(regs)
-    if nregs != num:
-        raise ValueError(f"expected {num} hyperparameters, got {nregs}")
+    if nregs not in (2,3):
+        raise ValueError(f"expected 2 or 3 hyperparameters, got {nregs}")
 
     # Check non-negativity.
     if any(λ < 0 for λ in regs):
@@ -178,9 +175,9 @@ def save_trained_rom(trainsize, r, regs, rom):
         Dimension of the ROM. Also the number of retained POD modes
         (left singular vectors) used to project the training data.
 
-    regs : two or three positive floats
-        Regularization parameters (non-quadratic, quadratic) used in the
-        Operator Inference least-squares problem for training the ROM.
+    regs : two or three non-negative floats
+        regularization hyperparameters (first-order, quadratic, cubic) used
+        in the Operator Inference least-squares problem for training the ROM.
 
     rom : rom_operator_inference.InferredContinuousROM
         Actual trained ROM object. Must have a `save_model()` method.
@@ -205,15 +202,16 @@ def train_single(trainsize, r, regs):
         Dimension of the desired ROM. Also the number of retained POD modes
         (left singular vectors) used to project the training data.
 
-    regs : two or three positive floats
+    regs : two or three non-negative floats
         Regularization hyperparameters (first-order, quadratic, cubic) to use
         in the Operator Inference least-squares problem for training the ROM.
     """
     utils.reset_logger(trainsize)
 
     # Validate inputs.
-    check_lstsq_size(trainsize, r, modelform="cAHB")
-    check_regs(regs, len(regs))
+    modelform = "cAHB" if len(regs) == 2 else "cAHGB"
+    check_lstsq_size(trainsize, r, modelform)
+    check_regs(regs)
 
     # Load training data.
     Q_, Qdot_, t = utils.load_projected_data(trainsize, r)
@@ -222,12 +220,12 @@ def train_single(trainsize, r, regs):
     # Train and save the ROM.
     with utils.timed_block(f"Training ROM with k={trainsize:d}, "
                            f"{config.REGSTR(regs)}"):
-        rom = opinf.InferredContinuousROM("cAHB")
-        rom.fit(None, Q_, Qdot_, U, P=regularizer(r, λ1, λ2))
+        rom = opinf.InferredContinuousROM(modelform)
+        rom.fit(None, Q_, Qdot_, U, P=regularizer(r, *list(regs)))
         save_trained_rom(trainsize, r, regs, rom)
 
 
-def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
+def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.1):
     """Train ROMs with the given dimension over a grid of potential
     regularization hyperparameters, saving only the ROM with the least
     training error that satisfies a bound on the integrated POD coefficients.
@@ -242,14 +240,15 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
         (left singular vectors) used to project the training data.
 
     regs : (float, float, int, float, float, int)
-        Bounds and sizes for the grid of regularization parameters.
-        Linear:    search in [regs[0], regs[1]] at regs[2] points.
-        Quadratic: search in [regs[3], regs[4]] at regs[5] points.
+        Bounds and sizes for the grid of regularization hyperparameters.
+        First-order: search in [regs[0], regs[1]] at regs[2] points.
+        Quadratic:   search in [regs[3], regs[4]] at regs[5] points.
+        Cubic:       search in [regs[6], regs[7]] at regs[8] points.
 
     testsize : int
         Number of time steps for which a valid ROM must satisfy the POD bound.
 
-    margin : float >= 1
+    margin : float ≥ 1
         Amount that the integrated POD coefficients of a valid ROM are allowed
         to deviate in magnitude from the maximum magnitude of the training
         data Q, i.e., bound = margin * max(abs(Q)).
@@ -257,13 +256,15 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
     utils.reset_logger(trainsize)
 
     # Parse aguments.
-    d = check_lstsq_size(trainsize, r, modelform="cAHB")
-    if len(regs) != 6:
-        raise ValueError("len(regs) != 6 (bounds / sizes for parameter grid")
-    check_regs(regs[0:2])
-    check_regs(regs[3:5])
-    λ1grid = np.logspace(np.log10(regs[0]), np.log10(regs[1]), int(regs[2]))
-    λ2grid = np.logspace(np.log10(regs[3]), np.log10(regs[4]), int(regs[5]))
+    if len(regs) not in [6, 9]:
+        raise ValueError("6 or 9 regs required (bounds / sizes of grids")
+    grids = []
+    for i in range(0, len(regs), 3):
+        check_regs(regs[i:i+2])
+        grids.append(np.logspace(np.log10(regs[i]),
+                                 np.log10(regs[i+1]), int(regs[i+2])))
+    modelform = "cAHB" if len(grids) == 2 else "cAHGB"
+    d = check_lstsq_size(trainsize, r, modelform)
 
     # Load training data.
     t = utils.load_time_domain(testsize)
@@ -273,21 +274,21 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
     # Compute the bound to require for integrated POD modes.
     M = margin * np.abs(Q_).max()
 
-    # Create a solver mapping regularization parameters to operators.
-    num_tests = λ1grid.size*λ2grid.size
+    # Create a solver mapping regularization hyperparameters to operators.
+    num_tests = np.prod([grid.size for grid in grids])
     print(f"TRAINING {num_tests} ROMS")
     with utils.timed_block(f"Constructing least-squares solver, r={r:d}"):
-        rom = opinf.InferredContinuousROM("cAHB")
+        rom = opinf.InferredContinuousROM(modelform)
         rom._construct_solver(None, Q_, Qdot_, U, np.ones(d))
 
-    # Test each regularization parameter.
+    # Test each regularization hyperparameter.
     errors_pass = {}
     errors_fail = {}
-    for i, (λ1,λ2) in enumerate(itertools.product(λ1grid, λ2grid)):
+    for i, regs in enumerate(itertools.product(*grids)):
         with utils.timed_block(f"({i+1:d}/{num_tests:d}) Testing ROM with "
-                               f"λ1={λ1:5e}, λ2={λ2:5e}"):
+                               f"{config.REGSTR(regs)}"):
             # Train the ROM on all training snapshots.
-            rom._evaluate_solver(regularizer(r, λ1, λ2))
+            rom._evaluate_solver(regularizer(r, *list(regs)))
 
             # Simulate the ROM over the full domain.
             with np.warnings.catch_warnings():
@@ -299,9 +300,9 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
 
             # Calculate integrated relative errors in the reduced space.
             if q_rom.shape[1] > trainsize:
-                errors[(λ1,λ2)] = opinf.post.Lp_error(Q_,
-                                                      q_rom[:,:trainsize],
-                                                      t[:trainsize])[1]
+                errors[tuple(regs)] = opinf.post.Lp_error(Q_,
+                                                          q_rom[:,:trainsize],
+                                                          t[:trainsize])[1]
 
     # Choose and save the ROM with the least error.
     if not errors_pass:
@@ -311,14 +312,14 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.5):
         return
 
     err2reg = {err:reg for reg,err in errors_pass.items()}
-    λ1,λ2 = err2reg[min(err2reg.keys())]
+    regs = list(err2reg[min(err2reg.keys())])
     with utils.timed_block(f"Best regularization for k={trainsize:d}, "
-                           f"r={r:d}: λ1={λ1:.0f}, λ2={λ2:.0f}"):
-        rom._evaluate_solver(regularizer(r, λ1, λ2))
-        save_trained_rom(trainsize, r, (λ1,λ2), rom)
+                           f"r={r:d}: {config.REGSTR(regs)}"):
+        rom._evaluate_solver(regularizer(r, *regs))
+        save_trained_rom(trainsize, r, regs, rom)
 
 
-def train_minimize(trainsize, r, regs, testsize=None, margin=1.5):
+def train_minimize(trainsize, r, regs, testsize=None, margin=1.1):
     """Train ROMs with the given dimension(s), saving only the ROM with
     the least training error that satisfies a bound on the integrated POD
     coefficients, using a search algorithm to choose the regularization
@@ -341,7 +342,7 @@ def train_minimize(trainsize, r, regs, testsize=None, margin=1.5):
     testsize : int
         Number of time steps for which a valid ROM must satisfy the POD bound.
 
-    margin : float >= 1
+    margin : float ≥ 1
         Amount that the integrated POD coefficients of a valid ROM are allowed
         to deviate in magnitude from the maximum magnitude of the training
         data Q, i.e., bound = margin * max(abs(Q)).
@@ -349,7 +350,8 @@ def train_minimize(trainsize, r, regs, testsize=None, margin=1.5):
     utils.reset_logger(trainsize)
 
     # Parse aguments.
-    d = check_lstsq_size(trainsize, r, modelform="cAHB")
+    modelform = "cAHB" if len(regs) == 2 else "cAHGB"
+    d = check_lstsq_size(trainsize, r, modelform)
     log10regs = np.log10(check_regs(regs))
 
     # Load training data.
@@ -360,22 +362,22 @@ def train_minimize(trainsize, r, regs, testsize=None, margin=1.5):
     # Compute the bound to require for integrated POD modes.
     B = margin * np.abs(Q_).max()
 
-    # Create a solver mapping regularization parameters to operators.
+    # Create a solver mapping regularization hyperparameters to operators.
     with utils.timed_block(f"Constructing least-squares solver, r={r:d}"):
-        rom = opinf.InferredContinuousROM("cAHB")
+        rom = opinf.InferredContinuousROM(modelform)
         rom._construct_solver(None, Q_, Qdot_, U, np.ones(d))
 
-    # Test each regularization parameter.
+    # Test each regularization hyperparameter.
     def training_error(log10regs):
         """Return the training error resulting from the regularization
         parameters λ1 = 10^log10regs[0], λ1 = 10^log10regs[1]. If the
         resulting model violates the POD bound, return "infinity".
         """
-        λ1, λ2 = 10**log10regs
+        regs = list(10**log10regs)
 
         # Train the ROM on all training snapshots.
-        with utils.timed_block(f"Testing ROM with λ1={λ1:e}, λ2={λ2:e}"):
-            rom._evaluate_solver(regularizer(r, λ1, λ2))
+        with utils.timed_block(f"Testing ROM with {config.REGSTR(regs)}"):
+            rom._evaluate_solver(regularizer(r, *regs))
 
             # Simulate the ROM over the full domain.
             with np.warnings.catch_warnings():
@@ -393,238 +395,20 @@ def train_minimize(trainsize, r, regs, testsize=None, margin=1.5):
 
     opt_result = opt.minimize(training_error, log10regs, method="Nelder-Mead")
     if opt_result.success and opt_result.fun != _MAXFUN:
-        λ1, λ2 = 10**opt_result.x
+        regs = list(10**opt_result.x)
         with utils.timed_block(f"Best regularization for k={trainsize:d}, "
-                               f"r={r:d}: λ1={λ1:.0f}, λ2={λ2:.0f}"):
-            rom._evaluate_solver(regularizer(r, λ1, λ2))
-            save_trained_rom(trainsize, r, (λ1,λ2), rom)
+                               f"r={r:d}: {config.REGSTR(regs)}"):
+            rom._evaluate_solver(regularizer(r, *regs))
+            save_trained_rom(trainsize, r, regs, rom)
     else:
         message = "Regularization search optimization FAILED"
         print(message)
         logging.info(message)
 
 
-# CUBIC MODELS ================================================================
-
-def train_single_cubic(trainsize, r, regs):
-    """Train and save a ROM with the given dimension and regularization
-    hyperparameters.
-
-    Parameters
-    ----------
-    trainsize : int
-        Number of snapshots to use to train the ROM.
-
-    r : int
-        Dimension of the desired ROM. Also the number of retained POD modes
-        (left singular vectors) used to project the training data.
-
-    regs : three non-negative floats
-        Regularization hyperparameters (first-order, quadratic, cubic) to use
-        in the Operator Inference least-squares problem for training the ROM.
-    """
-    utils.reset_logger(trainsize)
-
-    # Validate inputs.
-    check_lstsq_size(trainsize, r, modelform="cAHGB")
-    λ1, λ2, λ3 = check_regs(regs)
-
-    # Load training data.
-    Q_, Qdot_, t = utils.load_projected_data(trainsize, r)
-    U = config.U(t)
-
-    # Train and save the ROM.
-    with utils.timed_block(f"Training ROM with k={trainsize:d}, "
-                           f"r={r:d}, λ1={λ1:.0f}, λ2={λ2:.0f}, λ3={λ2:.0f}"):
-        rom = opinf.InferredContinuousROM("cAHGB")
-        rom.fit(None, Q_, Qdot_, U, P=regularizer(r, λ1, λ2, λ3))
-        save_trained_rom(trainsize, r, regs, rom)
-
-
-def train_gridsearch_cubic(trainsize, r, regs, testsize=None, margin=1.5):
-    """Train ROMs with the given dimension over a grid of potential
-    regularization hyperparameters, saving only the ROM with the least
-    training error that satisfies a bound on the integrated POD coefficients.
-
-    Parameters
-    ----------
-    trainsize : int
-        Number of snapshots to use to train the ROM.
-
-    r : int
-        Dimension of the desired ROM. Also the number of retained POD modes
-        (left singular vectors) used to project the training data.
-
-    regs : (float, float, int, float, float, int, float, float, int)
-        Bounds and sizes for the grid of regularization parameters.
-        First-order: search in [regs[0], regs[1]] at regs[2] points.
-        Quadratic:   search in [regs[3], regs[4]] at regs[5] points.
-        Cubic:       search in [regs[6], regs[7]] at regs[8] points.
-
-    testsize : int
-        Number of time steps for which a valid ROM must satisfy the POD bound.
-
-    margin : float >= 1
-        Amount that the integrated POD coefficients of a valid ROM are allowed
-        to deviate in magnitude from the maximum magnitude of the training
-        data Q, i.e., bound = margin * max(abs(Q)).
-    """
-    utils.reset_logger(trainsize)
-
-    # Parse aguments.
-    d = check_lstsq_size(trainsize, r, modelform="cAHGB")
-    if len(regs) != 9:
-        raise ValueError("len(regs) != 9 (bounds / sizes for parameter grid")
-    for i in [0, 3, 6]:
-        check_regs(regs[i:i+2], 2)
-    λ1grid = np.logspace(np.log10(regs[0]), np.log10(regs[1]), int(regs[2]))
-    λ2grid = np.logspace(np.log10(regs[3]), np.log10(regs[4]), int(regs[5]))
-    λ3grid = np.logspace(np.log10(regs[6]), np.log10(regs[7]), int(regs[8]))
-
-    # Load training data.
-    t = utils.load_time_domain(testsize)
-    Q_, Qdot_, _ = utils.load_projected_data(trainsize, r)
-    U = config.U(t[:trainsize])
-
-    # Compute the bound to require for integrated POD modes.
-    M = margin * np.abs(Q_).max()
-
-    # Create a solver mapping regularization parameters to operators.
-    num_tests = λ1grid.size*λ2grid.size*λ3grid.size
-    print(f"TRAINING {num_tests} ROMS")
-    with utils.timed_block(f"Constructing least-squares solver, r={r:d}"):
-        rom = opinf.InferredContinuousROM("cAHGB")
-        rom._construct_solver(None, Q_, Qdot_, U, np.ones(d))
-
-    # Test each regularization parameter.
-    errors_pass = {}
-    errors_fail = {}
-    for i, (λ1,λ2,λ3) in enumerate(itertools.product(λ1grid, λ2grid, λ3grid)):
-        with utils.timed_block(f"({i+1:d}/{num_tests:d}) Testing ROM with "
-                               f"λ1={λ1:5e}, λ2={λ2:5e}, λ3={λ3:5e}"):
-            # Train the ROM on all training snapshots.
-            rom._evaluate_solver(regularizer(r, λ1, λ2, λ3))
-
-            # Simulate the ROM over the full domain.
-            with np.warnings.catch_warnings():
-                np.warnings.simplefilter("ignore")
-                q_rom = rom.predict(Q_[:,0], t, config.U, method="RK45")
-
-            # Check for boundedness of solution.
-            errors = errors_pass if is_bounded(q_rom, M) else errors_fail
-
-            # Calculate integrated relative errors in the reduced space.
-            if q_rom.shape[1] > trainsize:
-                errors[(λ1,λ2,λ3)] = opinf.post.Lp_error(Q_,
-                                                         q_rom[:,:trainsize],
-                                                         t[:trainsize])[1]
-
-    # Choose and save the ROM with the least error.
-    if not errors_pass:
-        message = f"NO STABLE ROMS for r={r:d}"
-        print(message)
-        logging.info(message)
-        return
-
-    err2reg = {err:reg for reg,err in errors_pass.items()}
-    λ1,λ2,λ3 = err2reg[min(err2reg.keys())]
-    with utils.timed_block(f"Best regularization for k={trainsize:d}, "
-                           f"r={r:d}: λ1={λ1:.0f}, λ2={λ2:.0f}, λ3={λ3:.0f}"):
-        rom._evaluate_solver(regularizer(r, λ1, λ2, λ3))
-        save_trained_rom(trainsize, r, (λ1,λ2,λ3), rom)
-
-
-def train_minimize_cubic(trainsize, r, regs, testsize=None, margin=1.5):
-    """Train ROMs with the given dimension(s), saving only the ROM with
-    the least training error that satisfies a bound on the integrated POD
-    coefficients, using a search algorithm to choose the regularization
-    hyperparameters.
-
-    Parameters
-    ----------
-    trainsize : int
-        Number of snapshots to use to train the ROM.
-
-    r : int
-        Dimension of the desired ROM. Also the number of retained POD modes
-        (left singular vectors) used to project the training data.
-
-    regs : three non-negative floats
-        Initial guesses for the regularization hyperparameters (first-order,
-        quadratic, cubic) to use in the Operator Inference least-squares
-        problem for training the ROM.
-
-    testsize : int
-        Number of time steps for which a valid ROM must satisfy the POD bound.
-
-    margin : float >= 1
-        Amount that the integrated POD coefficients of a valid ROM are allowed
-        to deviate in magnitude from the maximum magnitude of the training
-        data Q, i.e., bound = margin * max(abs(Q)).
-    """
-    utils.reset_logger(trainsize)
-
-    # Parse aguments.
-    d = check_lstsq_size(trainsize, r, modelform="cAHGB")
-    log10regs = np.log10(check_regs(regs, 3))
-
-    # Load training data.
-    t = utils.load_time_domain(testsize)
-    Q_, Qdot_, _ = utils.load_projected_data(trainsize, r)
-    U = config.U(t[:trainsize])
-
-    # Compute the bound to require for integrated POD modes.
-    B = margin * np.abs(Q_).max()
-
-    # Create a solver mapping regularization parameters to operators.
-    with utils.timed_block(f"Constructing least-squares solver, r={r:d}"):
-        rom = opinf.InferredContinuousROM("cAHGB")
-        rom._construct_solver(None, Q_, Qdot_, U, np.ones(d))
-
-    # Test each regularization parameter.
-    def training_error(log10regs):
-        """Return the training error resulting from the regularization
-        parameters λ1 = 10^log10regs[0], λ1 = 10^log10regs[1]. If the
-        resulting model violates the POD bound, return "infinity".
-        """
-        λ1, λ2, λ3 = 10**log10regs
-
-        # Train the ROM on all training snapshots.
-        with utils.timed_block("Testing ROM with "
-                               f"λ1={λ1:e}, λ2={λ2:e}, λ3={λ3:e}"):
-            rom._evaluate_solver(regularizer(r, λ1, λ2, λ3))
-
-            # Simulate the ROM over the full domain.
-            with np.warnings.catch_warnings():
-                np.warnings.simplefilter("ignore")
-                q_rom = rom.predict(Q_[:,0], t, config.U, method="RK45")
-
-            # Check for boundedness of solution.
-            if not is_bounded(q_rom, B):
-                return _MAXFUN
-
-            # Calculate integrated relative errors in the reduced space.
-            return opinf.post.Lp_error(Q_,
-                                       q_rom[:,:trainsize],
-                                       t[:trainsize])[1]
-
-    opt_result = opt.minimize(training_error, log10regs, method="Nelder-Mead")
-    if opt_result.success and opt_result.fun != _MAXFUN:
-        λ1, λ2, λ3 = 10**opt_result.x
-        with utils.timed_block(f"Best regularization for k={trainsize:d}, "
-                               f"r={r:d}: λ1={λ1:.0f}, "
-                               f"λ2={λ2:.0f}, λ3={λ3:.0f}"):
-            rom._evaluate_solver(regularizer(r, λ1, λ2, λ3))
-            save_trained_rom(trainsize, r, (λ1,λ2,λ3), rom)
-    else:
-        message = "Regularization search optimization FAILED"
-        print(message)
-        logging.info(message)
-
-
-# First draft approach: single regularization parameter, i.e., ================
+# First draft approach: single regularization hyperparameter, i.e., ===========
 # equally penalize all entries of the ROM operators. ==========================
-def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
+def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.1):
     """Train ROMs with the given dimension(s), saving only the ROM with
     the least training error that satisfies a bound on the integrated POD
     coefficients, using a search algorithm to choose the regularization
@@ -639,14 +423,14 @@ def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
         Dimension of the desired ROM. Also the number of retained POD modes
         (left singular vectors) used to project the training data.
 
-    regs : positive floats
-        Bounds for the regularization parameter to use in the Operator
-        Inference least-squares problem for training the ROM.
+    regs : two non-negative floats
+        Bounds for the (single) regularization hyperparameter to use in the
+        Operator Inference least-squares problem for training the ROM.
 
     testsize : int
         Number of time steps for which a valid ROM must satisfy the POD bound.
 
-    margin : float >= 1
+    margin : float ≥ 1
         Amount that the integrated POD coefficients of a valid ROM are allowed
         to deviate in magnitude from the maximum magnitude of the training
         data Q, i.e., bound = margin * max(abs(Q)).
@@ -655,7 +439,7 @@ def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
 
     # Parse aguments.
     check_lstsq_size(trainsize, r, modelform="cAHB")
-    log10regs = np.log10(check_regs(regs))
+    log10regs = np.log10(regs)
 
     # Load training data.
     t = utils.load_time_domain(testsize)
@@ -665,12 +449,12 @@ def _train_minimize_1D(trainsize, r, regs, testsize=None, margin=1.5):
     # Compute the bound to require for integrated POD modes.
     B = margin * np.abs(Q_).max()
 
-    # Create a solver mapping regularization parameters to operators.
+    # Create a solver mapping regularization hyperparameters to operators.
     with utils.timed_block(f"Constructing least-squares solver, r={r:d}"):
         rom = opinf.InferredContinuousROM("cAHB")
         rom._construct_solver(None, Q_, Qdot_, U, 1)
 
-    # Test each regularization parameter.
+    # Test each regularization hyperparameter.
     def training_error(log10reg):
         """Return the training error resulting from the regularization
         hyperparameters λ1 = λ2 = 10^log10reg. If the resulting model
@@ -747,7 +531,7 @@ if __name__ == "__main__":
                         help="number of POD modes used to project the data "
                              "(dimension of ROM to be learned)")
     parser.add_argument("regularization", type=float, nargs='+',
-                        help="regularization parameters for ROM training")
+                        help="regularization hyperparameters for ROM training")
 
     # Other keyword arguments.
     parser.add_argument("--testsize", type=int, default=None,
@@ -761,23 +545,10 @@ if __name__ == "__main__":
     # Parse arguments and do one of the main routines.
     args = parser.parse_args()
     if args.single:
-        if len(args.regularization) == 3:
-            train_single_cubic(args.trainsize, args.modes, args.regularization)
-        else:
-            train_single(args.trainsize, args.modes, args.regularization)
+        train_single(args.trainsize, args.modes, args.regularization)
     elif args.gridsearch:
-        if len(args.regularization) == 9:
-            train_gridsearch_cubic(args.trainsize, args.modes,
-                                   args.regularization,
-                                   args.testsize, args.margin)
-        else:
-            train_gridsearch(args.trainsize, args.modes, args.regularization,
-                             args.testsize, args.margin)
+        train_gridsearch(args.trainsize, args.modes, args.regularization,
+                         args.testsize, args.margin)
     elif args.minimize:
-        if len(args.regularization) == 3:
-            train_minimize_cubic(args.trainsize, args.modes,
-                                 args.regularization,
-                                 args.testsize, args.margin)
-        else:
-            train_minimize(args.trainsize, args.modes, args.regularization,
-                           args.testsize, args.margin)
+        train_minimize(args.trainsize, args.modes, args.regularization,
+                       args.testsize, args.margin)

--- a/step3_train.py
+++ b/step3_train.py
@@ -63,6 +63,27 @@ _MAXFUN = 100               # Artificial ceiling for optimization routine.
 
 # Subroutines =================================================================
 
+def get_modelform(regs):
+    """Return the rom_operator_inference ROM modelform that is appropriate for
+    the number of regularization parameters (fully quadratic or fully cubic).
+
+    Parameters
+    ----------
+    regs : two or three non-negative floats
+        Regularization hyperparameters for Operator Inference.
+
+    Returns
+    -------
+    modelform : str
+        'cAHB' for fully quadratic ROM; 'cAHGB' for fully cubic ROM.
+    """
+    if np.isscalar(regs) or len(regs) == 2:
+        return "cAHB"
+    elif len(regs) == 3:
+        return "cAHGB"
+    raise ValueError("expected 2 or 3 regularization hyperparameters")
+
+
 def check_lstsq_size(trainsize, r, modelform="cAHB"):
     """Report the number of unknowns in the Operator Inference problem,
     compared to the number of snapshots. Ask user for confirmation before
@@ -209,7 +230,7 @@ def train_single(trainsize, r, regs):
     utils.reset_logger(trainsize)
 
     # Validate inputs.
-    modelform = "cAHB" if len(regs) == 2 else "cAHGB"
+    modelform = get_modelform(regs)
     check_lstsq_size(trainsize, r, modelform)
     check_regs(regs)
 
@@ -263,7 +284,7 @@ def train_gridsearch(trainsize, r, regs, testsize=None, margin=1.1):
         check_regs(regs[i:i+2])
         grids.append(np.logspace(np.log10(regs[i]),
                                  np.log10(regs[i+1]), int(regs[i+2])))
-    modelform = "cAHB" if len(grids) == 2 else "cAHGB"
+    modelform = get_modelform(grids)
     d = check_lstsq_size(trainsize, r, modelform)
 
     # Load training data.
@@ -350,7 +371,7 @@ def train_minimize(trainsize, r, regs, testsize=None, margin=1.1):
     utils.reset_logger(trainsize)
 
     # Parse aguments.
-    modelform = "cAHB" if len(regs) == 2 else "cAHGB"
+    modelform = get_modelform(regs)
     d = check_lstsq_size(trainsize, r, modelform)
     log10regs = np.log10(check_regs(regs))
 

--- a/step4_plot.py
+++ b/step4_plot.py
@@ -60,7 +60,7 @@ def simulate_rom(trainsize, r, regs, steps=None):
     r : int
         Dimension of the ROM.
 
-    regs : two positive floats
+    regs : two or three positive floats
         Regularization hyperparameters used to train the ROM.
 
     steps : int or None
@@ -90,11 +90,10 @@ def simulate_rom(trainsize, r, regs, steps=None):
     V, qbar, scales = utils.load_basis(trainsize, r)
     Q_, _, _ = utils.load_projected_data(trainsize, r)
     rom = utils.load_rom(trainsize, r, regs)
-    λ1, λ2 = regs
 
     # Simulate the ROM over the full time domain.
     with utils.timed_block(f"Simulating ROM with k={trainsize:d}, r={r:d}, "
-                           f"λ1={λ1:.0f}, λ2={λ2:.0f} over full time domain"):
+                           f"{config.REGSTR(regs)} over full time domain"):
         q_rom = rom.predict(Q_[:,0], t, config.U, method="RK45")
 
     return t, V, qbar, scales, q_rom
@@ -192,7 +191,7 @@ def point_traces(trainsize, r, regs, elems, cutoff=60000):
     r : int
         Dimension of the ROM.
 
-    regs : two positive floats
+    regs : two or three positive floats
         Regularization hyperparameters used to train the ROM.
 
     elems : list(int) or ndarray(int)
@@ -253,10 +252,7 @@ def point_traces(trainsize, r, regs, elems, cutoff=60000):
             line.set_linewidth(2)
 
         # Save the figure.
-        utils.save_figure("pointtrace"
-                          f"_{config.TRNFMT(trainsize)}"
-                          f"_{config.DIMFMT(r)}"
-                          f"_{config.REGFMT(regs)}_{var}.pdf")
+        utils.save_figure(f"pointtrace_{var}.pdf")
 
 
 def errors_in_time(trainsize, r, regs, cutoff=60000):
@@ -270,7 +266,7 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
     r : int
         Dimension of the ROM.
 
-    regs : two positive floats
+    regs : two or three positive floats
         Regularization hyperparameters used to train the ROM.
 
     cutoff : int
@@ -334,10 +330,7 @@ def errors_in_time(trainsize, r, regs, cutoff=60000):
         line.set_linewidth(5)
 
     # Save the figure.
-    utils.save_figure(f"errors"
-                      f"_{config.TRNFMT(trainsize)}"
-                      f"_{config.DIMFMT(r)}"
-                      f"_{config.REGFMT(regs)}.pdf")
+    utils.save_figure("errors.pdf")
 
 
 def save_statistical_features():
@@ -397,7 +390,7 @@ def spatial_statistics(trainsize, r, regs):
     r : int
         Dimension of the ROM.
 
-    regs : two positive floats
+    regs : two or three positive floats
         Regularization hyperparameters used to train the ROM.
     """
     # Load the true results.
@@ -439,10 +432,7 @@ def spatial_statistics(trainsize, r, regs):
     for line in leg.get_lines():
         line.set_linewidth(2)
 
-    utils.save_figure(f"statfeatures"
-                      f"_{config.TRNFMT(trainsize)}"
-                      f"_{config.DIMFMT(r)}"
-                      f"_{config.REGFMT(regs)}.pdf")
+    utils.save_figure("statfeatures.pdf")
 
 
 # Main routine ================================================================
@@ -504,7 +494,7 @@ if __name__ == "__main__":
     parser.add_argument("modes", type=int,
                         help="number of POD modes used to project the data"
                              " (dimension of the learned ROM)")
-    parser.add_argument("regularization", type=float, nargs=2,
+    parser.add_argument("regularization", type=float, nargs='+',
                         help="regularization hyperparameters used in the "
                              "Operator Inference problem for learning the ROM")
 

--- a/utils.py
+++ b/utils.py
@@ -9,12 +9,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 try:
-    import rom_operator_inference as roi
+    import rom_operator_inference as opinf
 except ModuleNotFoundError:
     print("\nrom_operator_inference module not installed",
           "(python3 -m pip install --user -r requirements.txt)\n")
     raise
-if roi.__version__ != "1.2.1":
+if opinf.__version__ != "1.2.1":
     raise ModuleNotFoundError("rom-operator-inference version 1.2.1 required "
                               "(python3 -m pip install --user "
                               "-r requirements.txt)")
@@ -342,7 +342,7 @@ def load_rom(trainsize, r, regs):
 
     Returns
     -------
-    rom : roi.InferredContinuousROM
+    rom : opinf.InferredContinuousROM
         The trained reduced-order model.
     """
     # Locate the data.
@@ -350,7 +350,7 @@ def load_rom(trainsize, r, regs):
 
     # Extract the trained ROM.
     try:
-        rom = roi.load_model(data_path)
+        rom = opinf.load_model(data_path)
     except FileNotFoundError as e:
         raise DataNotFoundError(f"could not locate ROM with {trainsize:d} "
                                 f"training snapshots, r={r:d}, and "

--- a/utils.py
+++ b/utils.py
@@ -336,9 +336,9 @@ def load_rom(trainsize, r, regs):
         Dimension of the ROM. Also the number of retained POD modes (left
         singular vectors) used to project the training data.
 
-    regs : two positive floats
-        Regularization parameters used in the Operator Inference least-squares
-        problem for training the ROM.
+    regs : one, two, or three positive floats
+        Regularization hyperparameters used in the Operator Inference
+        least-squares problem for training the ROM.
 
     Returns
     -------
@@ -353,13 +353,13 @@ def load_rom(trainsize, r, regs):
         rom = roi.load_model(data_path)
     except FileNotFoundError as e:
         raise DataNotFoundError(f"could not locate ROM with {trainsize:d} "
-                                f"training snapshots, r={r:d}, "
-                                f"and λ1={regs[0]:e}, λ2={regs[1]:e}") from e
+                                f"training snapshots, r={r:d}, and "
+                                f"{config.REGSTR(regs)}") from e
     # Check ROM dimension.
     if rom.r != r:
         raise RuntimeError(f"rom.r = {rom.r} != {r}")
 
-    rom.trainsize, rom.λ1, rom.λ2 = trainsize, regs[0], regs[1]
+    rom.trainsize, rom.regs = trainsize, regs
     return rom
 
 

--- a/utils.py
+++ b/utils.py
@@ -221,14 +221,18 @@ def load_scaled_data(trainsize):
                 raise RuntimeError("data set 'data' has incorrect shape")
             if hf["time"].shape != (trainsize,):
                 raise RuntimeError("data set 'time' has incorrect shape")
-            if hf["mean"].shape != (hf["data"].shape[0],):
-                raise RuntimeError("data set 'mean' has incorrect shape")
+            if "mean" in hf:
+                if hf["mean"].shape != (hf["data"].shape[0],):
+                    raise RuntimeError("data set 'mean' has incorrect shape")
+                mean = hf["mean"][:]
+            else:
+                mean = np.zeros(hf["data"].shape[0])
             if hf["scales"].shape != (config.NUM_ROMVARS, 2):
                 raise RuntimeError("data set 'scales' has incorrect shape")
 
             # Load and return the data.
             return (hf["data"][:,:], hf["time"][:],
-                    hf["mean"][:], hf["scales"][:,:])
+                    mean, hf["scales"][:,:])
 
 
 def load_basis(trainsize, r):
@@ -271,11 +275,15 @@ def load_basis(trainsize, r):
             rmax = hf["basis"].shape[1]
             if r is not None and rmax < r:
                 raise ValueError(f"basis only has {rmax} columns")
-            if hf["mean"].shape != (hf["basis"].shape[0],):
-                raise RuntimeError("basis and mean snapshot not aligned!")
+            if "mean" in hf:
+                if hf["mean"].shape != (hf["basis"].shape[0],):
+                    raise RuntimeError("basis and mean snapshot not aligned!")
+                mean = hf["mean"][:]
+            else:
+                mean = np.zeros(hf["basis"].shape[0])
 
             # Load the data.
-            return hf["basis"][:,:r], hf["mean"][:], hf["scales"][:]
+            return hf["basis"][:,:r], mean, hf["scales"][:]
 
 
 def load_projected_data(trainsize, r):


### PR DESCRIPTION
Added support for cubic Operator Inference reduced-order models. Examples (each with `k=20000` training snapshots and `r=30` basis vectors):
- `python3 step3_train.py --single 20000 30 10 100`: compute / save a single quadratic ROM with regularization hyperparameters 10 (first-order terms) and 100 (quadratic terms). This was the old behavior and is still valid.
- `python3 step3_train.py --single 20000 30 10 100 1000`: compute / save a single **cubic** ROM with regularization hyperparameters 10 (first-order terms), 100 (quadratic terms), and 1000 (cubic terms). This is new behavior.
- `python3 step3_train.py --gridsearch 20000 30 10 20 4 100 200 5`: gridsearch for quadratic ROM.
- `python3 step3_train.py --gridsearch 20000 30 10 20 4 100 200 5 1000 2000 6`: gridsearch for **cubic** ROM.
- `python3 step3_train.py --minimize 20000 30 10 100`: optimal hyperparameter search for quadratic ROM.
- `python3 step3_train.py --minimize 20000 30 10 100 1000`: optimal hyperparameter search for **cubic** ROM.
- `python3 step4_plot.py --point-traces

Other changes:
- ROM files (managed through the `rom_operator_inference` package) are now named with timestamps, e.g., `2021-05-03_22:56:30.h5`. These files live in the same place as before, e.g., `k20000/r020/2021-05-03_22:56:30.h5`.
- Regularization parameters used for each ROM are stored in `roms.json`, e.g., `k20000/roms.json`.
- Updated `inventory.py` accordingly
- Added `--clean` option to `inventory.py` to reconcile file system and `roms.json` files
- Added command line option `--center` to center the scaled snapshots before computing the POD basis. This option defaults to FALSE (PR #6  set centering as the default behavior; also fixed a bug introduced due to changes in that PR).
- Some corrections / updates to doc strings